### PR TITLE
refactor document controller

### DIFF
--- a/app/scripts/controllers/document-import.js
+++ b/app/scripts/controllers/document-import.js
@@ -8,7 +8,7 @@ angular.module('lorryApp').controller('DocumentImportCtrl', ['$scope', 'ngDialog
       title: 'Import compose.yml'
     };
 
-    $scope.importDialog = function () {
+    $scope.showImportDialog = function () {
       $scope.dialog = ngDialog.open({
         template: '/views/import-dialog.html',
         className: 'ngdialog-theme-lorry',
@@ -21,12 +21,12 @@ angular.module('lorryApp').controller('DocumentImportCtrl', ['$scope', 'ngDialog
       $scope.dialogOptions.dialogPane = pane;
     };
 
-    $scope.importYaml = function() {
+    $scope.importYaml = function(docImport) {
       switch ($scope.dialogOptions.dialogPane) {
         case 'remote':
           break;
         case 'paste':
-          $scope.validateYaml();
+          $scope.yamlDocument.raw = docImport.raw;
           break;
         default:
           $scope.upload();
@@ -39,7 +39,6 @@ angular.module('lorryApp').controller('DocumentImportCtrl', ['$scope', 'ngDialog
       fr.addEventListener('load', function(e) {
         $scope.$apply(function(){
           $scope.yamlDocument.raw = e.target.result;
-          $scope.validateYaml();
         });
       });
       fr.readAsText($scope.files[0]);

--- a/app/scripts/directives/action-menu.js
+++ b/app/scripts/directives/action-menu.js
@@ -3,13 +3,12 @@
 angular.module('lorryApp')
   .directive('actionMenu', function () {
     return {
-      scope: false,
       restrict: 'E',
       replace: true,
       link: function postLink(scope, element, attrs) {
         scope.deleteServiceDefinition = function () {
           var serviceName = scope.serviceName();
-          scope.$emit('deleteService', serviceName);
+          scope.$parent.deleteService(serviceName);
         }
       },
       templateUrl: '/scripts/directives/action-menu.html'

--- a/app/views/document.html
+++ b/app/views/document.html
@@ -1,6 +1,6 @@
 <div id="documentActionsPane" ng-controller="DocumentImportCtrl">
   <div id="documentImportPane" ng-if="importable">
-    <a class="button-primary" href="" ng-click="importDialog()">Import compose.yml</a>
+    <a class="button-primary" href="" ng-click="showImportDialog()">Import compose.yml</a>
   </div>
   <div id="documentResetPane" ng-if="resettable">
     <a class="button-secondary" href="" ng-click="resetWorkspace()">Clear Workspace</a>

--- a/app/views/import-dialog.html
+++ b/app/views/import-dialog.html
@@ -19,15 +19,15 @@
     </div>
     <div ng-show="dialogOptions.dialogPane === 'paste'">
       <p>Paste your compose.yml contents below</p>
-      <textarea placeholder="Paste or write your YAML here" ng-model="yamlDocument.raw"></textarea>
+      <textarea placeholder="Paste or write your YAML here" ng-model="docImport.raw"></textarea>
     </div>
     <div ng-show="dialogOptions.dialogPane === 'remote'">
       <p>Paste the full URI of your remote compose.yml</p>
-      <input type="text">
+      <input type="text" ng-model="docImport.remote">
     </div>
   </div>
   <div class="dialog-footer">
-    <button class="button-primary" ng-click="importYaml()">Import</button>
+    <button class="button-primary" ng-click="importYaml(docImport)">Import</button>
     <button class="button-secondary" ng-click="closeThisDialog()">Cancel</button>
   </div>
 </form>

--- a/test/spec/controllers/document-import.js
+++ b/test/spec/controllers/document-import.js
@@ -39,10 +39,11 @@ describe('Controller: DocumentImportCtrl', function () {
     });
 
     describe("when the dialogPane is 'paste'", function () {
-      it('triggers validateYaml on the $parent scope', function () {
+      it('it sets the value pasted into $scope.yamlDocument.raw', function () {
+        var docImport = {raw: 'asdf'};
         scope.dialogOptions.dialogPane = 'paste';
-        scope.importYaml();
-        expect(scope.validateYaml).toHaveBeenCalled();
+        scope.importYaml(docImport);
+        expect(scope.yamlDocument.raw).toEqual(docImport.raw);
       });
     });
 
@@ -72,22 +73,13 @@ describe('Controller: DocumentImportCtrl', function () {
       scope.upload();
     });
 
-    it('sets the uploaded document into scope', function() {
+    it('sets the uploaded document contents into scope', function() {
       eventListener.calls.mostRecent().args[1]({
         target : {
           result : 'foo: file content'
         }
       });
       expect(scope.yamlDocument.raw).toEqual('foo: file content');
-    });
-
-    it('triggers validation of the document', function() {
-      eventListener.calls.mostRecent().args[1]({
-        target : {
-          result : 'foo: file content'
-        }
-      });
-      expect(scope.validateYaml).toHaveBeenCalled();
     });
   });
 });

--- a/test/spec/controllers/document.js
+++ b/test/spec/controllers/document.js
@@ -26,7 +26,7 @@ describe('Controller: DocumentCtrl', function () {
       beforeEach(inject(function($q) {
         deferredSuccess = $q.defer();
         spyOn(yamlValidator, 'validate').and.returnValue(deferredSuccess.promise);
-        scope.validateYaml();
+        DocumentCtrl.validateYaml();
         deferredSuccess.resolve({data: {lines: ['line'], errors: ['error']}});
         scope.$digest();
       }));
@@ -56,7 +56,7 @@ describe('Controller: DocumentCtrl', function () {
 
       describe('due to a status other than 500 (e.g. 422)', function () {
         beforeEach(inject(function() {
-          scope.validateYaml();
+          DocumentCtrl.validateYaml();
           deferredError.reject({data: {error: 'something went wrong'}});
           scope.$digest();
         }));
@@ -77,7 +77,7 @@ describe('Controller: DocumentCtrl', function () {
 
       describe('when validation fails because of a 500 error', function () {
         beforeEach(inject(function() {
-          scope.validateYaml();
+          DocumentCtrl.validateYaml();
           deferredError.reject({status: 500, data: {error: 'something went wrong'}});
           scope.$digest();
         }));
@@ -106,6 +106,7 @@ describe('Controller: DocumentCtrl', function () {
 
   describe('yamlDocument.raw watcher', function () {
     beforeEach(function () {
+      spyOn(DocumentCtrl, 'validateYaml');
       scope.resettable = false;
       scope.importable = true;
       scope.yamlDocument = {};
@@ -172,23 +173,22 @@ describe('Controller: DocumentCtrl', function () {
   describe('$scope.validateJson', function () {
     describe('when the yamlDocument has no/empty json', function () {
       beforeEach(function () {
-        spyOn(scope, 'resetWorkspace');
-        spyOn(scope, 'validateYaml');
+        spyOn(DocumentCtrl, 'reset');
       });
 
       it('resets the workspace', function () {
         scope.yamlDocument.json = {};
-        scope.validateJson();
-        expect(scope.resetWorkspace).toHaveBeenCalled();
+        DocumentCtrl.validateJson();
+        expect(DocumentCtrl.reset).toHaveBeenCalled();
       });
     });
 
     describe('when the yamlDocument has json', function () {
       beforeEach(function () {
-        spyOn(scope, 'validateYaml');
+        spyOn(DocumentCtrl, 'validateYaml');
         scope.yamlDocument.raw = null;
         scope.yamlDocument.json = {'foo': 'bar'};
-        scope.validateJson();
+        DocumentCtrl.validateJson();
       });
 
       it('stores the yamlized json into the yamlDocument.raw property', function () {
@@ -196,35 +196,35 @@ describe('Controller: DocumentCtrl', function () {
       });
 
       it('calls validatesYaml', function () {
-        expect(scope.validateYaml).toHaveBeenCalled();
+        expect(DocumentCtrl.validateYaml).toHaveBeenCalled();
       });
     });
   });
 
-  describe('deleteService event handler', function () {
+  describe('deleteService', function () {
     beforeEach(function () {
-      spyOn(scope, 'validateJson');
+      spyOn(DocumentCtrl, 'validateJson');
     });
 
     describe('when the yamlDocument.json has a service matching the serviceName in the event', function () {
       beforeEach(function () {
         scope.yamlDocument.json = { someService: [] };
-        scope.$emit('deleteService', 'someService');
+        scope.deleteService('someService');
       });
 
-      it('should not change the yamlDocument.json', function () {
+      it('should change the yamlDocument.json', function () {
         expect(scope.yamlDocument.json).toEqual({});
       });
 
-      it('should not call validateJson', function () {
-        expect(scope.validateJson).toHaveBeenCalled();
+      it('should call validateJson', function () {
+        expect(DocumentCtrl.validateJson).toHaveBeenCalled();
       });
     });
 
     describe('when the yamlDocument.json does not have a service matching the serviceName in the event', function () {
       beforeEach(function () {
         scope.yamlDocument.json = { someOtherService: [] };
-        scope.$emit('deleteService', 'someService');
+        scope.deleteService('someService');
       });
 
       it('should not change the yamlDocument.json', function () {
@@ -232,75 +232,7 @@ describe('Controller: DocumentCtrl', function () {
       });
 
       it('should not call validateJson', function () {
-        expect(scope.validateJson).not.toHaveBeenCalled();
-      });
-    });
-  });
-
-  describe('$scope.validateJson', function () {
-    describe('when the yamlDocument has no/empty json', function () {
-      beforeEach(function () {
-        spyOn(scope, 'resetWorkspace');
-        spyOn(scope, 'validateYaml');
-      });
-
-      it('resets the workspace', function () {
-        scope.yamlDocument.json = {};
-        scope.validateJson();
-        expect(scope.resetWorkspace).toHaveBeenCalled();
-      });
-    });
-
-    describe('when the yamlDocument has json', function () {
-      beforeEach(function () {
-        spyOn(scope, 'validateYaml');
-        scope.yamlDocument.raw = null;
-        scope.yamlDocument.json = {'foo': 'bar'};
-        scope.validateJson();
-      });
-
-      it('stores the yamlized json into the yamlDocument.raw property', function () {
-        expect(scope.yamlDocument.raw).not.toBeNull();
-      });
-
-      it('calls validatesYaml', function () {
-        expect(scope.validateYaml).toHaveBeenCalled();
-      });
-    });
-  });
-
-  describe('deleteService event handler', function () {
-    beforeEach(function () {
-      spyOn(scope, 'validateJson');
-    });
-
-    describe('when the yamlDocument.json has a service matching the serviceName in the event', function () {
-      beforeEach(function () {
-        scope.yamlDocument.json = { someService: [] };
-        scope.$emit('deleteService', 'someService');
-      });
-
-      it('should not change the yamlDocument.json', function () {
-        expect(scope.yamlDocument.json).toEqual({});
-      });
-
-      it('should not call validateJson', function () {
-        expect(scope.validateJson).toHaveBeenCalled();
-      });
-    });
-
-    describe('when the yamlDocument.json does not have a service matching the serviceName in the event', function () {
-      beforeEach(function () {
-        scope.yamlDocument.json = { someOtherService: [] };
-        scope.$emit('deleteService', 'someService');
-      });
-
-      it('should not change the yamlDocument.json', function () {
-        expect(scope.yamlDocument.json).toEqual({ someOtherService: [] });
-      });
-
-      it('should not call validateJson', function () {
-        expect(scope.validateJson).not.toHaveBeenCalled();
+        expect(DocumentCtrl.validateJson).not.toHaveBeenCalled();
       });
     });
   });

--- a/test/spec/directives/action-menu.js
+++ b/test/spec/directives/action-menu.js
@@ -34,14 +34,17 @@ describe('Directive: actionMenu', function () {
     });
 
     it('is triggered when the delete icon is clicked', function () {
+      spyOn(scope, 'deleteServiceDefinition');
       var deleteIcon = element.find('.icon-x-large')[0];
       angular.element(deleteIcon).triggerHandler('click');
-      expect(scope.$emit).toHaveBeenCalled();
+      expect(scope.deleteServiceDefinition).toHaveBeenCalled();
     });
 
-    it('emits deleteService with the name of the service definition to be deleted', function () {
+    it('calls deleteService on the parent with the name of the service definition to be deleted', function () {
+      var p = jasmine.createSpyObj('$parent',['deleteService']);
+      scope.$parent = p;
       scope.deleteServiceDefinition();
-      expect(scope.$emit).toHaveBeenCalledWith('deleteService', 'someService');
+      expect(p.deleteService).toHaveBeenCalledWith('someService');
     });
   });
 


### PR DESCRIPTION
I've refactored the document controller with some general cleanup but primarily to stop polluting $scope with methods that are simply internal to the controller.  

Originally I had intended to move the documentYaml into a service, but this lead to a lot of message broadcasting and listeners (i.e. increased complexity).  Then I found a list of antipatterns at https://github.com/angular/angular.js/wiki/Best-Practices, and the use of services to manage shared object state was listed there.  As a result, I chose to keep the yamlDocument in the document controller and reduce the number of methods on scope.
