### PR TITLE
Preprocessing directive templates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist
 .tmp
 .sass-cache
 bower_components
+app/scripts/directives/templates.js

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -34,8 +34,8 @@ module.exports = function (grunt) {
         tasks: ['wiredep']
       },
       js: {
-        files: ['<%= yeoman.app %>/scripts/{,*/}*.js'],
-        tasks: ['newer:jshint:all'],
+        files: ['<%= yeoman.app %>/scripts/{,*/}*.js', '<%= yeoman.app %>/scripts/directives/**/*.html'],
+        tasks: ['html2js', 'newer:jshint:all'],
         options: {
           livereload: '<%= connect.options.livereload %>'
         }
@@ -229,6 +229,23 @@ module.exports = function (grunt) {
       }
     },
 
+    // pre-process angular templates
+    html2js: {
+      options: {
+        base: 'app',
+        rename: function (moduleName) {
+          return '/' + moduleName;
+        },
+        useStrict: true,
+        quoteChar: '\'',
+        module: 'directive-templates'
+      },
+      dist: {
+        src: [ '<%= yeoman.app %>/scripts/directives/**/*.html' ],
+        dest: '<%= yeoman.app %>/scripts/directives/templates.js'
+      }
+    },
+
     // Reads HTML for usemin blocks to enable smart builds that automatically
     // concat, minify and revision files. Creates configurations in memory so
     // additional tasks can operate on them
@@ -411,6 +428,7 @@ module.exports = function (grunt) {
     grunt.task.run([
       'clean:server',
       'wiredep',
+      'html2js',
       'concurrent:server',
       'autoprefixer',
       'connect:livereload',
@@ -429,12 +447,14 @@ module.exports = function (grunt) {
     'concurrent:test',
     'autoprefixer',
     'connect:test',
+    'html2js',
     'karma'
   ]);
 
   grunt.registerTask('build', [
     'clean:dist',
     'wiredep',
+    'html2js',
     'useminPrepare',
     'concurrent:dist',
     'autoprefixer',

--- a/app/index.html
+++ b/app/index.html
@@ -51,6 +51,7 @@
     <!-- endbuild -->
 
         <!-- build:js({.tmp,app}) scripts/scripts.js -->
+        <script src="scripts/directives/templates.js"></script>
         <script src="scripts/app.js"></script>
         <script src="scripts/controllers/main.js"></script>
         <script src="scripts/controllers/search.js"></script>

--- a/app/scripts/app.js
+++ b/app/scripts/app.js
@@ -9,6 +9,7 @@ angular
     'ngSanitize',
     'ngLodash',
     'ngDialog',
+    'directive-templates',
     'angular.filter',
     'docker-registry'
   ])

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "grunt-contrib-watch": "^0.6.1",
     "grunt-filerev": "^2.1.2",
     "grunt-google-cdn": "^0.4.3",
+    "grunt-html2js": "^0.3.0",
     "grunt-karma": "^0.10.1",
     "grunt-newer": "^0.8.0",
     "grunt-ng-annotate": "^0.10.0",

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -16,15 +16,6 @@ module.exports = function(config) {
     // testing framework to use (jasmine/mocha/qunit/...)
     frameworks: ['jasmine'],
 
-    preprocessors: {
-      'app/scripts/directives/*.html': 'ng-html2js'
-    },
-
-    ngHtml2JsPreprocessor: {
-      stripPrefix: 'app',
-      moduleName: 'tpl'
-    },
-
     // list of files / patterns to load in the browser
     files: [
       // bower:js
@@ -43,8 +34,7 @@ module.exports = function(config) {
       // endbower
       'app/scripts/**/*.js',
       'test/mock/**/*.js',
-      'test/spec/**/*.js',
-      'app/scripts/directives/*.html'
+      'test/spec/**/*.js'
     ],
 
     // list of files / patterns to exclude
@@ -70,8 +60,7 @@ module.exports = function(config) {
     plugins: [
       'karma-phantomjs-launcher',
       'karma-jasmine',
-      'karma-spec-reporter',
-      'karma-ng-html2js-preprocessor'
+      'karma-spec-reporter'
     ],
 
     // Continuous Integration mode

--- a/test/spec/directives/action-menu.js
+++ b/test/spec/directives/action-menu.js
@@ -4,8 +4,6 @@ describe('Directive: actionMenu', function () {
 
   beforeEach(module('lorryApp'));
 
-  beforeEach(module('tpl'));
-
   var parentScope, scope,
     compile,
     element;

--- a/test/spec/directives/document-line-edit.js
+++ b/test/spec/directives/document-line-edit.js
@@ -4,8 +4,6 @@ describe('Directive: documentLineEdit', function () {
 
   beforeEach(module('lorryApp'));
 
-  beforeEach(module('tpl'));
-
   var scope, compile, element;
 
   beforeEach(inject(function($compile, $rootScope){

--- a/test/spec/directives/service-definition-display.js
+++ b/test/spec/directives/service-definition-display.js
@@ -4,8 +4,6 @@ describe('Directive: serviceDefinitionDisplay', function () {
 
   beforeEach(module('lorryApp'));
 
-  beforeEach(module('tpl'));
-
   var scope,
     compile,
     element;

--- a/test/spec/directives/service-definition-edit.js
+++ b/test/spec/directives/service-definition-edit.js
@@ -4,8 +4,6 @@ describe('Directive: serviceDefinitionEdit', function () {
 
   beforeEach(module('lorryApp'));
 
-  beforeEach(module('tpl'));
-
   var scope,
     compile,
     element;


### PR DESCRIPTION
Adding the html2js tasks to preprocess directive templates and add themto the angular template cache.
Removing the karma preprocessor which does the same as the html2js preprocessor.
Adding the generated template module to the angular app and removing references to the karma template module.
