### PR TITLE
wrapping jsyaml in a service

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -67,6 +67,7 @@
         <script src="scripts/directives/file-input.js"></script>
         <script src="scripts/controllers/document-import.js"></script>
         <script src="scripts/directives/action-menu.js"></script>
+        <script src="scripts/services/jsyaml.js"></script>
         <!-- endbuild -->
 </body>
 </html>

--- a/app/scripts/controllers/document.js
+++ b/app/scripts/controllers/document.js
@@ -1,7 +1,7 @@
 'use strict';
 
-angular.module('lorryApp').controller('DocumentCtrl', ['$scope', '$log', 'lodash', 'yamlValidator', 'serviceDefTransformer',
-  function ($scope, $log, lodash, yamlValidator, serviceDefTransformer) {
+angular.module('lorryApp').controller('DocumentCtrl', ['$scope', '$log', 'lodash', 'jsyaml', 'yamlValidator', 'serviceDefTransformer',
+  function ($scope, $log, lodash, jsyaml, yamlValidator, serviceDefTransformer) {
 
     var self = this;
 
@@ -22,7 +22,7 @@ angular.module('lorryApp').controller('DocumentCtrl', ['$scope', '$log', 'lodash
 
     $scope.$watchCollection('yamlDocument.raw', function() {
       var documentDefined = (angular.isDefined($scope.yamlDocument) && angular.isDefined($scope.yamlDocument.raw));
-      if (documentDefined) self.validateYaml();
+      if (documentDefined) { self.validateYaml(); }
       $scope.resettable = documentDefined;
       $scope.importable = !documentDefined;
     });
@@ -72,7 +72,7 @@ angular.module('lorryApp').controller('DocumentCtrl', ['$scope', '$log', 'lodash
     };
 
     $scope.serviceName = function (srvcDef) {
-      return srvcDef[0].text.split(':')[0]
+      return srvcDef[0].text.split(':')[0];
     };
 
   }]);

--- a/app/scripts/services/jsyaml.js
+++ b/app/scripts/services/jsyaml.js
@@ -1,0 +1,11 @@
+'use strict';
+
+angular.module('lorryApp').factory('jsyaml', function ($window) {
+    if ($window.jsyaml) {
+      $window._thirdParty = $window._thirdParty || {};
+      $window._thirdParty.jsyaml = $window.jsyaml;
+      try { delete $window.jsyaml; } catch (e) {$window.jsyaml = undefined;}
+    }
+    var jsyaml = $window._thirdParty.jsyaml;
+    return jsyaml;
+  });

--- a/test/spec/services/jsyaml.js
+++ b/test/spec/services/jsyaml.js
@@ -1,0 +1,18 @@
+'use strict';
+
+describe('Service: jsyaml', function () {
+
+  // load the service's module
+  beforeEach(module('lorryApp'));
+
+  // instantiate service
+  var jsyaml;
+  beforeEach(inject(function (_jsyaml_) {
+    jsyaml = _jsyaml_;
+  }));
+
+  it('should do something', function () {
+    expect(!!jsyaml).toBe(true);
+  });
+
+});


### PR DESCRIPTION
to get rid of some jshint warnings. To not access third-party libraries off window, jsyaml was converted to a service.
