### PR TITLE
Make add/delete changes to keys/items locally to editableJson to preserve state

### DIFF
--- a/app/scripts/controllers/document.js
+++ b/app/scripts/controllers/document.js
@@ -147,28 +147,6 @@ angular.module('lorryApp').controller('DocumentCtrl', ['$rootScope', '$scope', '
       delete $scope.yamlDocument.json[serviceName].editMode;
     });
 
-    this.createNewEmptyValueForKey = function(key) {
-      var keyValue;
-
-      switch (key) {
-        case 'links':
-        case 'external_links':
-        case 'ports':
-        case 'volumes':
-        case 'environment':
-          keyValue = [''];
-          break;
-        case 'command':
-        case 'image':
-        case 'build':
-          keyValue = '';
-          break;
-        default:
-          keyValue = '';
-      }
-      return keyValue;
-    };
-
     this.deleteItemsMarkedForDeletion = function(data) {
       var tracker = $rootScope.markAsDeletedTracker;
 
@@ -189,68 +167,6 @@ angular.module('lorryApp').controller('DocumentCtrl', ['$rootScope', '$scope', '
 
       return data;
     };
-
-    this.markItemForDeletion = function(key, index) {
-      var tracker = $rootScope.markAsDeletedTracker;
-
-      // toggle add/remove items from the delete marker
-      if (tracker.hasOwnProperty(key)) {
-        if (index != null) {
-          if (lodash.includes(tracker[key], index)) {
-            // remove the item from tracker
-            lodash.remove(tracker[key], function (v) {
-              return v == index;
-            });
-            // if no items in tracker, delete the key
-            if (lodash.size(tracker[key]) == 0) {
-              delete tracker[key];
-            }
-          } else {
-            // add the item to the tracker
-            tracker[key].push(index);
-          }
-        } else {
-          delete tracker[key];
-        }
-      } else {
-        // add key/index to tracker
-        tracker[key] = [];
-        if (index != null) {
-          tracker[key].push(index);
-        } else {
-          tracker[key].push('delete me');
-        }
-      }
-    };
-
-    $scope.$on('addNewKeyToSection', function (e, key) {
-      var keyValue = self.createNewEmptyValueForKey(key);
-      $scope.editedServiceYamlDocumentJson[key] = keyValue;
-    });
-
-    $scope.$on('addNewValueForExistingKey', function (e, key) {
-      var json = $scope.editedServiceYamlDocumentJson;
-      if (json.hasOwnProperty(key)) {
-        var keyValue = self.createNewEmptyValueForKey(key);
-        if (Array.isArray(keyValue)) {
-          json[key].push(keyValue[0]);
-        }
-      }
-    });
-
-    $scope.$on('markKeyForDeletion', function (e, key) {
-      var json = $scope.editedServiceYamlDocumentJson;
-      if (json.hasOwnProperty(key)) {
-        self.markItemForDeletion(key, null);
-      }
-    });
-
-    $scope.$on('markKeyItemForDeletion', function (e, key, index) {
-      var json = $scope.editedServiceYamlDocumentJson;
-      if (json.hasOwnProperty(key)) {
-        self.markItemForDeletion(key, index);
-      }
-    });
 
     $scope.serviceNames = function () {
       return lodash.keys($scope.yamlDocument.json);

--- a/test/spec/controllers/document.js
+++ b/test/spec/controllers/document.js
@@ -386,32 +386,12 @@ describe('Controller: DocumentCtrl', function () {
     });
   });
 
-  describe('#createNewEmptyValueForKey', function () {
-    ['command', 'image', 'build'].forEach(function (key) {
-      describe('when the key (' + key + ') represents a string value', function () {
-        it('returns an empty string', function () {
-          var result = DocumentCtrl.createNewEmptyValueForKey(key);
-          expect(result).toBe('');
-        });
-      });
-    });
-
-    ['links', 'external_links', 'ports', 'volumes', 'environment'].forEach(function (key) {
-      describe('when the key (' + key + ') represents a string value', function () {
-        it('returns an empty array', function () {
-          var result = DocumentCtrl.createNewEmptyValueForKey(key);
-          expect(result).toEqual(['']);
-        });
-      });
-    });
-
-  });
-
   describe('#deleteItemsMarkedForDeletion', function () {
     describe('when some keys and items in a key are deleted', function () {
       beforeEach(function () {
-        DocumentCtrl.markItemForDeletion('build', null);
-        DocumentCtrl.markItemForDeletion('ports', 0);
+        // simulate deletes as marked
+        scope.markAsDeletedTracker['build'] = ['delete me'];
+        scope.markAsDeletedTracker['ports'] = ['0'];
       });
 
       it('should delete the items marked for deletion', function () {
@@ -438,9 +418,10 @@ describe('Controller: DocumentCtrl', function () {
 
     describe('when all the items in a key are deleted', function () {
       beforeEach(function () {
-        DocumentCtrl.markItemForDeletion('build', null);
-        DocumentCtrl.markItemForDeletion('ports', 0);
-        DocumentCtrl.markItemForDeletion('ports', 1);
+        // simulate deletes as marked
+        scope.markAsDeletedTracker['build'] = ['delete me'];
+        scope.markAsDeletedTracker['ports'] = ['0'];
+        scope.markAsDeletedTracker['ports'] = ['1'];
       });
 
       it('should delete the whole key', function () {
@@ -454,59 +435,6 @@ describe('Controller: DocumentCtrl', function () {
         expect(result).not.hasOwnProperty('ports');
       });
     });
-  });
-
-  describe('#markItemForDeletion', function () {
-
-    describe('when a key is deleted', function () {
-      beforeEach(function () {
-        DocumentCtrl.markItemForDeletion('key1', null);
-      });
-
-      it('should add the key name to delete tracker', function () {
-        expect(scope.markAsDeletedTracker).hasOwnProperty('key1');
-        expect(scope.markAsDeletedTracker['key1']).toEqual(['delete me']);
-      });
-    });
-
-    describe('when a key is un-deleted', function () {
-      beforeEach(function () {
-        DocumentCtrl.markItemForDeletion('key1', null);
-      });
-
-      it('should remove the key name from the delete tracker', function () {
-        // undelete key
-        DocumentCtrl.markItemForDeletion('key1', null);
-        expect(scope.markAsDeletedTracker).not.hasOwnProperty('key1');
-      });
-    });
-
-    describe('when key items are deleted', function () {
-      beforeEach(function () {
-        DocumentCtrl.markItemForDeletion('key2', 0);
-        DocumentCtrl.markItemForDeletion('key2', 1);
-      });
-
-      it('should add the key item indexes to the delete tracker', function () {
-        expect(scope.markAsDeletedTracker).hasOwnProperty('key2');
-        expect(scope.markAsDeletedTracker['key2']).toEqual([0,1]);
-      });
-    });
-
-    describe('when a key item is un-deleted', function () {
-      beforeEach(function () {
-        DocumentCtrl.markItemForDeletion('key2', 0);
-        DocumentCtrl.markItemForDeletion('key2', 1);
-      });
-
-      it('should remove the key item index from the delete tracker', function () {
-        // undelete only one item
-        DocumentCtrl.markItemForDeletion('key2', 1);
-        expect(scope.markAsDeletedTracker).hasOwnProperty('key2');
-        expect(scope.markAsDeletedTracker['key2']).toEqual([0]);
-      });
-    });
-
   });
 
   describe('$scope.$on saveService', function () {
@@ -609,8 +537,9 @@ describe('Controller: DocumentCtrl', function () {
     describe('when editing is cancelled', function () {
       beforeEach(function () {
         // simulate some deletes
-        DocumentCtrl.markItemForDeletion('build', null);
-        DocumentCtrl.markItemForDeletion('ports', 0);
+        scope.markAsDeletedTracker['build'] = ['delete me'];
+        scope.markAsDeletedTracker['ports'] = ['0'];
+
         // call cancel
         scope.$emit('cancelEditing', 'service1');
       });
@@ -624,159 +553,6 @@ describe('Controller: DocumentCtrl', function () {
       });
     });
 
-  });
-
-  describe('$scope.$on addNewKeyToSection', function () {
-    beforeEach(function () {
-      scope.editedServiceYamlDocumentJson = {
-        "build": "foo",
-        "ports": ["1111:2222", "3333:4444"]
-      };
-    });
-
-    describe('when a string key is added', function () {
-      beforeEach(function () {
-        scope.$emit('addNewKeyToSection', 'command');
-      });
-
-      it('should add a new key to the service with empty value', function () {
-        expect(scope.editedServiceYamlDocumentJson).hasOwnProperty('command');
-        expect(scope.editedServiceYamlDocumentJson['command']).toBe('');
-      });
-    });
-
-    describe('when a sequence key is added', function () {
-      beforeEach(function () {
-        scope.$emit('addNewKeyToSection', 'volumes');
-      });
-
-      it('should add a new key with empty sequence', function () {
-        expect(scope.editedServiceYamlDocumentJson).hasOwnProperty('volumes');
-        expect(scope.editedServiceYamlDocumentJson['volumes']).toEqual(['']);
-      });
-    });
-
-  });
-
-  describe('$scope.$on addNewValueForExistingKey', function () {
-    beforeEach(function () {
-      scope.editedServiceYamlDocumentJson = {
-        "build": "foo",
-        "ports": ["1111:2222", "3333:4444"]
-      };
-    });
-
-    describe('when a string key value is added', function () {
-      beforeEach(function () {
-        scope.$emit('addNewValueForExistingKey', 'command');
-      });
-
-      it('should not add a new key value', function () {
-        expect(scope.editedServiceYamlDocumentJson).not.hasOwnProperty('command');
-      });
-    });
-
-    describe('when a sequence key value is added', function () {
-      beforeEach(function () {
-        scope.$emit('addNewValueForExistingKey', 'ports');
-      });
-
-      it('should add a new key value to the section with empty sequence', function () {
-        expect(scope.editedServiceYamlDocumentJson).hasOwnProperty('ports');
-        expect(scope.editedServiceYamlDocumentJson['ports']).toEqual(["1111:2222", "3333:4444", ""]);
-      });
-    });
-
-    describe('when a key value is added to a non-existent key', function () {
-      beforeEach(function () {
-        scope.$emit('addNewValueForExistingKey', 'invalid');
-      });
-
-      it('should not add a new key value', function () {
-        !expect(scope.editedServiceYamlDocumentJson).hasOwnProperty('invalid');
-      });
-    });
-
-  });
-
-  describe('$scope.$on markKeyForDeletion', function () {
-    beforeEach(function () {
-      scope.editedServiceYamlDocumentJson = {
-        "build": "foo",
-        "ports": ["1111:2222", "3333:4444"]
-      };
-    });
-
-    describe('when a string key is deleted', function () {
-      beforeEach(function () {
-        scope.$emit('markKeyForDeletion', 'build');
-      });
-
-      it('should mark the key for deletion', function () {
-        expect(scope.markAsDeletedTracker).hasOwnProperty('build');
-      });
-    });
-
-    describe('when a sequence key is deleted', function () {
-      beforeEach(function () {
-        scope.$emit('markKeyForDeletion', 'ports');
-      });
-
-      it('should mark the key for deletion', function () {
-        expect(scope.markAsDeletedTracker).hasOwnProperty('ports');
-      });
-    });
-
-    describe('when a non-existent key is deleted', function () {
-      beforeEach(function () {
-        scope.$emit('markKeyForDeletion', 'invalid');
-        spyOn(DocumentCtrl, 'markItemForDeletion');
-      });
-
-      it('should not mark the key for deletion', function () {
-        expect(scope.markAsDeletedTracker).toEqual({});
-      });
-
-      it('should not call markItemsForDeletion', function () {
-        expect(DocumentCtrl.markItemForDeletion).not.toHaveBeenCalled();
-      });
-    });
-
-  });
-
-  describe('$scope.$on markKeyItemForDeletion', function () {
-    beforeEach(function () {
-      scope.editedServiceYamlDocumentJson = {
-        "build": "foo",
-        "ports": ["1111:2222", "3333:4444"]
-      };
-    });
-
-    describe('when an existing key item is deleted', function () {
-      beforeEach(function () {
-        scope.$emit('markKeyItemForDeletion', 'ports', 0);
-      });
-
-      it('should mark the key item for deletion', function () {
-        expect(scope.markAsDeletedTracker).hasOwnProperty('ports');
-        expect(scope.markAsDeletedTracker['ports']).toEqual([0]);
-      });
-    });
-
-    describe('when a non-existent key is deleted', function () {
-      beforeEach(function () {
-        scope.$emit('markKeyItemForDeletion', 'invalid');
-        spyOn(DocumentCtrl, 'markItemForDeletion');
-      });
-
-      it('should not delete the key item from the service', function () {
-        expect(scope.editedServiceYamlDocumentJson['ports'].length).toBe(2);
-      });
-
-      it('should not call markItemsForDeletion', function () {
-        expect(DocumentCtrl.markItemForDeletion).not.toHaveBeenCalled();
-      });
-    });
   });
 
   describe('$scope.serviceNames', function () {

--- a/test/spec/directives/service-definition-edit.js
+++ b/test/spec/directives/service-definition-edit.js
@@ -165,28 +165,230 @@ describe('Directive: serviceDefinitionEdit', function () {
 
         element = compile('<service-definition-edit section-name="sectionName"></service-definition-edit>')(scope);
         scope.$digest();
-
-        spyOn(element.isolateScope(), '$emit');
       });
 
       it('is triggered when add new key is clicked on the dropdown', function () {
-        spyOn(lodash, 'includes').and.returnValue(true);
+        spyOn(element.isolateScope(), 'addNewKey');
         var addKeySelect = element.find('div select')[0];
         angular.element(addKeySelect).triggerHandler('change');
-        expect(element.isolateScope().$emit).toHaveBeenCalled();
+        expect(element.isolateScope().addNewKey).toHaveBeenCalled();
       });
 
-      it('emits addNewKeyToSection when section name and a new valid key is passed', function () {
-        var newValidKey = 'command';
-        element.isolateScope().addNewKey(newValidKey);
-        expect(element.isolateScope().$emit).toHaveBeenCalledWith('addNewKeyToSection', newValidKey);
+      describe('when a invalid', function () {
+        beforeEach(function () {
+          spyOn(lodash, 'includes').and.returnValue(false);
+        });
+
+        describe('string key is added', function () {
+          beforeEach(function () {
+            element.isolateScope().addNewKey('invalid');
+          });
+
+          it('should not add the invalid key to the editable json', function () {
+            expect(element.isolateScope().editableJson).not.toContain({"name": "invalid", "value": ''});
+          });
+          it('should not add the invalid key to the edited service', function () {
+            expect(scope.editedServiceYamlDocumentJson).not.hasOwnProperty('invalid');
+          });
+
+        });
+
+        describe('sequence key is added', function () {
+          beforeEach(function () {
+            element.isolateScope().addNewKey('invalid');
+          });
+
+          it('should not add the invalid key to the editable json', function () {
+            expect(element.isolateScope().editableJson).not.toContain({"name": "volumes", "value": ['']});
+          });
+          it('should add the invalid key to the edited service', function () {
+            expect(scope.editedServiceYamlDocumentJson).not.hasOwnProperty('invalid');
+          });
+        });
+
       });
 
-      it('does not emit addNewKeyToSection when section name and an invalid key is passed', function () {
-        var newInvalidKey = 'blah';
-        element.isolateScope().addNewKey(newInvalidKey);
-        expect(element.isolateScope().$emit).not.toHaveBeenCalledWith('addNewKeyToSection', newInvalidKey);
+      describe('when a valid', function () {
+        beforeEach(function () {
+          spyOn(lodash, 'includes').and.returnValue(true);
+        });
+
+        describe('string key is added', function () {
+          beforeEach(function () {
+            element.isolateScope().addNewKey('command');
+          });
+
+          it('should add a new key to the editable json with empty value', function () {
+            expect(element.isolateScope().editableJson).toContain({"name": "command", "value": ''});
+          });
+          it('should add a new key to the edited service with empty value', function () {
+            expect(scope.editedServiceYamlDocumentJson).hasOwnProperty('command');
+            expect(scope.editedServiceYamlDocumentJson['command']).toBe('');
+          });
+
+        });
+
+        describe('sequence key is added', function () {
+          beforeEach(function () {
+            element.isolateScope().addNewKey('volumes');
+          });
+
+          it('should add a new key to the editable json with empty sequence', function () {
+            expect(element.isolateScope().editableJson).toContain({"name": "volumes", "value": ['']});
+          });
+          it('should add a new key to the edited service with empty sequence', function () {
+            expect(scope.editedServiceYamlDocumentJson).hasOwnProperty('volumes');
+            expect(scope.editedServiceYamlDocumentJson['volumes']).toEqual(['']);
+          });
+        });
       });
+    });
+
+    describe('$scope.$on addNewValueForExistingKey', function () {
+      beforeEach(function () {
+        scope.sectionName = 'adapter';
+        scope.fullJson = {
+          "adapter": {
+            "build": "foo",
+            "ports": ["1111:2222", "3333:4444"]
+          }};
+        scope.editedServiceYamlDocumentJson = {
+          "build": "foo",
+          "ports": ["1111:2222", "3333:4444"]
+        };
+
+        element = compile('<service-definition-edit section-name="sectionName"></service-definition-edit>')(scope);
+        scope.$digest();
+
+        element.isolateScope().editableJson = [
+          {"name": "build", "value": "foo"},
+          {"name": "ports", "value": ["1111:2222", "3333:4444"]}
+        ];
+
+      });
+
+      describe('when a string key value is added', function () {
+        beforeEach(function () {
+          element.isolateScope().$emit('addNewValueForExistingKey', 'command');
+        });
+
+        it('should not add a new key value', function () {
+          expect(element.isolateScope().editableJson).not.toContain({"name": "command", "value": ''});
+          expect(scope.editedServiceYamlDocumentJson).not.hasOwnProperty('command');
+        });
+      });
+
+      describe('when a sequence key value is added', function () {
+        beforeEach(function () {
+          element.isolateScope().$emit('addNewValueForExistingKey', 'ports');
+        });
+
+        it('should add a new key value to the service with empty sequence', function () {
+          expect(element.isolateScope().editableJson[1]).toEqual({"name": "ports", "value": ["1111:2222", "3333:4444", ""]});
+          expect(scope.editedServiceYamlDocumentJson).hasOwnProperty('ports');
+          expect(scope.editedServiceYamlDocumentJson['ports']).toEqual(["1111:2222", "3333:4444", ""]);
+        });
+      });
+
+      describe('when a key value is added to a non-existent key', function () {
+        beforeEach(function () {
+          element.isolateScope().$emit('addNewValueForExistingKey', 'invalid');
+        });
+
+        it('should not add a new key value', function () {
+          expect(element.isolateScope().editableJson).not.toContain({"name": "invalid", "value": ['']});
+          !expect(scope.editedServiceYamlDocumentJson).hasOwnProperty('invalid');
+        });
+      });
+
+    });
+
+    describe('$scope.$on markKeyForDeletion', function () {
+      beforeEach(function () {
+        scope.sectionName = 'adapter';
+        scope.fullJson = {
+          "adapter": {
+            "build": "foo",
+            "ports": ["1111:2222", "3333:4444"]
+          }};
+
+        element = compile('<service-definition-edit section-name="sectionName"></service-definition-edit>')(scope);
+        scope.$digest();
+
+        element.isolateScope().editableJson = [
+          {"name": "build", "value": "foo"},
+          {"name": "ports", "value": ["1111:2222", "3333:4444"]}
+        ];
+
+        spyOn(element.isolateScope(), 'markItemForDeletion');
+      });
+
+      describe('when an existing key is marked for deletion', function () {
+        beforeEach(function () {
+          spyOn(lodash, 'findWhere').and.returnValue(true);
+          element.isolateScope().$emit('markKeyForDeletion', 'build');
+        });
+
+        it('should call markItemForDeletion with key and index as null', function () {
+          expect(element.isolateScope().markItemForDeletion).toHaveBeenCalledWith('build', null);
+        });
+      });
+
+      describe('when a non-existent key is marked for deletion', function () {
+        beforeEach(function () {
+          spyOn(lodash, 'findWhere').and.returnValue(false);
+          element.isolateScope().$emit('markKeyForDeletion', 'invalid');
+        });
+
+        it('should not call markItemForDeletion with key and null', function () {
+          expect(element.isolateScope().markItemForDeletion).not.toHaveBeenCalled();
+        });
+      });
+
+    });
+
+    describe('$scope.$on markKeyItemForDeletion', function () {
+      beforeEach(function () {
+        scope.sectionName = 'adapter';
+        scope.fullJson = {
+          "adapter": {
+            "build": "foo",
+            "ports": ["1111:2222", "3333:4444"]
+          }};
+
+        element = compile('<service-definition-edit section-name="sectionName"></service-definition-edit>')(scope);
+        scope.$digest();
+
+        element.isolateScope().editableJson = [
+          {"name": "build", "value": "foo"},
+          {"name": "ports", "value": ["1111:2222", "3333:4444"]}
+        ];
+
+        spyOn(element.isolateScope(), 'markItemForDeletion');
+      });
+
+      describe('when an existing key item is marked for deletion', function () {
+        beforeEach(function () {
+          spyOn(lodash, 'findWhere').and.returnValue(true);
+          element.isolateScope().$emit('markKeyItemForDeletion', 'ports', 1);
+        });
+
+        it('should call markItemForDeletion with key and index', function () {
+          expect(element.isolateScope().markItemForDeletion).toHaveBeenCalledWith('ports', 1);
+        });
+      });
+
+      describe('when a non-existent key item is marked for deletion', function () {
+        beforeEach(function () {
+          spyOn(lodash, 'findWhere').and.returnValue(false);
+          element.isolateScope().$emit('markKeyItemForDeletion', 'invalid', 1);
+        });
+
+        it('should not call markItemForDeletion', function () {
+          expect(element.isolateScope().markItemForDeletion).not.toHaveBeenCalled();
+        });
+      });
+
     });
 
     describe('$scope.buildValidKeyList', function () {
@@ -218,6 +420,90 @@ describe('Directive: serviceDefinitionEdit', function () {
 
     });
 
+    describe('#createNewEmptyValueForKey', function () {
+      beforeEach(function () {
+        scope.sectionName = 'adapter';
+        element = compile('<service-definition-edit section-name="sectionName"></service-definition-edit>')(scope);
+        scope.$digest();
+      });
+
+      ['command', 'image', 'build'].forEach(function (key) {
+        describe('when the key (' + key + ') represents a string value', function () {
+          it('returns an empty string', function () {
+            var result = element.isolateScope().createNewEmptyValueForKey(key);
+            expect(result).toBe('');
+          });
+        });
+      });
+
+      ['links', 'external_links', 'ports', 'volumes', 'environment'].forEach(function (key) {
+        describe('when the key (' + key + ') represents a string value', function () {
+          it('returns an empty array', function () {
+            var result = element.isolateScope().createNewEmptyValueForKey(key);
+            expect(result).toEqual(['']);
+          });
+        });
+      });
+
+    });
+
+    describe('#markItemForDeletion', function () {
+      beforeEach(function () {
+        scope.sectionName = 'adapter';
+        element = compile('<service-definition-edit section-name="sectionName"></service-definition-edit>')(scope);
+        scope.$digest();
+      });
+
+      describe('when a key is deleted', function () {
+        beforeEach(function () {
+          element.isolateScope().markItemForDeletion('key1', null);
+        });
+
+        it('should add the key name to delete tracker', function () {
+          expect(scope.markAsDeletedTracker).hasOwnProperty('key1');
+          expect(scope.markAsDeletedTracker['key1']).toEqual(['delete me']);
+        });
+      });
+
+      describe('when a key is un-deleted', function () {
+        beforeEach(function () {
+          element.isolateScope().markItemForDeletion('key1', null);
+        });
+
+        it('should remove the key name from the delete tracker', function () {
+          // undelete key
+          element.isolateScope().markItemForDeletion('key1', null);
+          expect(scope.markAsDeletedTracker).not.hasOwnProperty('key1');
+        });
+      });
+
+      describe('when key items are deleted', function () {
+        beforeEach(function () {
+          element.isolateScope().markItemForDeletion('key2', 0);
+          element.isolateScope().markItemForDeletion('key2', 1);
+        });
+
+        it('should add the key item indexes to the delete tracker', function () {
+          expect(scope.markAsDeletedTracker).hasOwnProperty('key2');
+          expect(scope.markAsDeletedTracker['key2']).toEqual([0,1]);
+        });
+      });
+
+      describe('when a key item is un-deleted', function () {
+        beforeEach(function () {
+          element.isolateScope().markItemForDeletion('key2', 0);
+          element.isolateScope().markItemForDeletion('key2', 1);
+        });
+
+        it('should remove the key item index from the delete tracker', function () {
+          // undelete only one item
+          element.isolateScope().markItemForDeletion('key2', 1);
+          expect(scope.markAsDeletedTracker).hasOwnProperty('key2');
+          expect(scope.markAsDeletedTracker['key2']).toEqual([0]);
+        });
+      });
+
+    });
   });
 
 });


### PR DESCRIPTION
[Finishes #91192848]

Make add/delete changes to keys/items locally to `editableJson` to preserve state in `editedServiceYamlDocumentJson`. Due to that change, moved the add/delete methods for keys/items from `document.js` into `service-definition-edit.js`. 

It also cleans `document.js` (and test file) and gets rid of internal edit/delete functionality for edit form.
