### PR TITLE
Visualize all images with ImageLayers

### DIFF
--- a/app/scripts/directives/action-menu.js
+++ b/app/scripts/directives/action-menu.js
@@ -8,7 +8,7 @@ angular.module('lorryApp')
       link: function postLink(scope) {
 
         scope.deleteServiceDefinition = function () {
-          if (!scope.$parent.inEditMode() && !scope.$parent.inNewServiceMode()) {
+          if (!scope.inEditMode() && !scope.inNewServiceMode()) {
             var serviceName = scope.serviceName();
 
             scope.confirmMessage = 'Are you sure you want to delete this block?';
@@ -20,15 +20,15 @@ angular.module('lorryApp')
                 scope: scope
               }
             ).then(function () {
-                scope.$parent.deleteService(serviceName);
+                scope.deleteService(serviceName);
               });
           }
         };
 
         scope.editServiceDefinition = function () {
-          if (!scope.$parent.inEditMode() && !scope.$parent.inNewServiceMode()) {
+          if (!scope.inEditMode() && !scope.inNewServiceMode()) {
             var serviceName = scope.serviceName();
-            scope.$parent.editService(serviceName);
+            scope.editService(serviceName);
           }
         };
 

--- a/app/scripts/directives/document-line.js
+++ b/app/scripts/directives/document-line.js
@@ -3,9 +3,6 @@
 angular.module('lorryApp').directive('documentLine', ['$compile', '$window', 'lodash', 'jsyaml', 'ENV',
   function ($compile, $window, lodash, jsyaml, ENV) {
     return {
-      scope: {
-        line: '='
-      },
       restrict: 'E',
       replace: true,
       link: function postLink(scope, element) {
@@ -37,12 +34,18 @@ angular.module('lorryApp').directive('documentLine', ['$compile', '$window', 'lo
           return imageObj.image;
         }
 
+        function imageNames() {
+          return lodash.pluck(lodash.filter(scope.yamlDocument.json, 'image'), 'image');
+        }
+
         scope.isImageLine = function () {
           return lodash.startsWith(scope.line.text.trim(), 'image:') && !lodash.isEmpty(imageName());
         };
 
         scope.showImageLayers = function () {
-          var imageLayersUrl = ENV.IMAGE_LAYERS_URL + 'images=' + encodeURIComponent(imageName());
+          var querystring = 'images=' + encodeURIComponent(imageNames().join(',')) +
+            '&' + 'lock=' + encodeURIComponent(imageName());
+          var imageLayersUrl = ENV.IMAGE_LAYERS_URL + querystring;
           $window.open(imageLayersUrl, '_blank');
         };
 

--- a/app/scripts/directives/service-definition-display.html
+++ b/app/scripts/directives/service-definition-display.html
@@ -1,5 +1,5 @@
 <div class="service-definition" ng-class="classes()">
   <action-menu></action-menu>
-  <document-line line="lineObj" ng-repeat="lineObj in serviceDefinition track by $index"></document-line>
+  <document-line ng-repeat="line in serviceDefinition track by $index"></document-line>
 </div>
 

--- a/app/scripts/directives/service-definition-display.js
+++ b/app/scripts/directives/service-definition-display.js
@@ -3,9 +3,6 @@
 angular.module('lorryApp')
   .directive('serviceDefinitionDisplay', ['lodash', function (lodash) {
     return {
-      scope: {
-        serviceDefinition: '='
-      },
       restrict: 'E',
       replace: 'true',
       link: function postLink(scope) {
@@ -16,7 +13,7 @@ angular.module('lorryApp')
         };
 
         scope.classes = function () {
-          return scope.hasLines() && !scope.$parent.inEditMode() && !scope.$parent.inNewServiceMode() ? 'highlightable' : 'disabled';
+          return scope.hasLines() && !scope.inEditMode() && !scope.inNewServiceMode() ? 'highlightable' : 'disabled';
         };
 
         scope.serviceName = function () {

--- a/app/views/document.html
+++ b/app/views/document.html
@@ -29,7 +29,7 @@
 
   <div id="documentPane" ng-init="getValidKeys()">
     <div ng-repeat="serviceDefinition in serviceDefinitions">
-      <service-definition-display ng-if="!yamlDocument.json[serviceName(serviceDefinition)].editMode" service-definition="serviceDefinition"></service-definition-display>
+      <service-definition-display ng-if="!yamlDocument.json[serviceName(serviceDefinition)].editMode"></service-definition-display>
       <service-definition-edit ng-if="yamlDocument.json[serviceName(serviceDefinition)].editMode" section-name="serviceName(serviceDefinition)"></service-definition-edit>
     </div>
     <div ng-if="!hasLoadFailure()">

--- a/test/spec/directives/action-menu.js
+++ b/test/spec/directives/action-menu.js
@@ -4,30 +4,22 @@ describe('Directive: actionMenu', function () {
 
   beforeEach(module('lorryApp'));
 
-  var parentScope, scope,
+  var scope,
     compile,
     ngDialog,
     element;
 
   beforeEach(inject(function($compile, $rootScope, _ngDialog_){
-    parentScope = $rootScope.$new();
     scope = $rootScope.$new();
     compile = $compile;
     ngDialog = _ngDialog_;
   }));
 
   beforeEach(function () {
-    var serviceDefDisplay = compile('<service-definition-display service-definition=""></service-definition-display>')(parentScope);
-    parentScope.$digest();
-    spyOn(serviceDefDisplay.isolateScope(), 'serviceName').and.returnValue('someService');
-    spyOn(serviceDefDisplay.isolateScope(), 'hasLines').and.returnValue(true);
-    spyOn(serviceDefDisplay.isolateScope(), 'classes');
-
-    element = angular.element('<action-menu enabled="true"></action-menu>');
-    serviceDefDisplay.append(element);
-
-    element = compile(element)(serviceDefDisplay.isolateScope());
-    scope = element.scope();
+    scope.serviceName = jasmine.createSpy('serviceName').and.returnValue('someService');
+    scope.hasLines = jasmine.createSpy('hasLines').and.returnValue(true);
+    scope.classes = jasmine.createSpy('classes');
+    element = compile('<action-menu></action-menu>')(scope);
     scope.$digest();
   });
 
@@ -41,20 +33,22 @@ describe('Directive: actionMenu', function () {
 
     describe('when the user cancels the delete action', function () {
       it('does not call deleteService on the parent scope', function () {
-        var p = jasmine.createSpyObj('$parent', ['deleteService', 'inEditMode', 'inNewServiceMode']);
-        scope.$parent = p;
+        scope.deleteService = jasmine.createSpy('deleteService');
+        scope.inEditMode = jasmine.createSpy('inEditMode');
+        scope.inNewServiceMode = jasmine.createSpy('inNewServiceMode');
+
         scope.deleteServiceDefinition();
         deferredSuccess.reject();
         scope.$digest();
-        expect(p.deleteService).not.toHaveBeenCalled();
+        expect(scope.deleteService).not.toHaveBeenCalled();
       });
     });
 
     describe('when the user confirms the delete action', function () {
       it('is triggered when the delete icon is clicked', function () {
         spyOn(scope, 'deleteServiceDefinition');
-        var deleteIcon = element.find('.icon-x')[0];
-        angular.element(deleteIcon).triggerHandler('click');
+        var deleteIcon = element.find('.icon-x');
+        deleteIcon.triggerHandler('click');
         deferredSuccess.resolve();
         scope.$digest();
         expect(scope.deleteServiceDefinition).toHaveBeenCalled();
@@ -62,47 +56,51 @@ describe('Directive: actionMenu', function () {
 
       describe('when any of the services are not in edit mode and new service is not being added', function () {
         it('calls deleteService on the parent with the name of the service definition to be deleted', function () {
-          var p = jasmine.createSpyObj('$parent', ['deleteService', 'inEditMode', 'inNewServiceMode']);
-          scope.$parent = p;
+          scope.deleteService = jasmine.createSpy('deleteService');
+          scope.inEditMode = jasmine.createSpy('inEditMode');
+          scope.inNewServiceMode = jasmine.createSpy('inNewServiceMode');
+
           scope.deleteServiceDefinition();
           deferredSuccess.resolve();
           scope.$digest();
-          expect(p.deleteService).toHaveBeenCalledWith('someService');
+          expect(scope.deleteService).toHaveBeenCalledWith('someService');
         });
       });
 
       describe('when any of the services are not in edit mode and new service is being added', function () {
         it('does not call deleteService on parent', function () {
-          var p = jasmine.createSpyObj('$parent', ['deleteService', 'inEditMode']);
-          p.inNewServiceMode = function () { return true; };
-          scope.$parent = p;
+          scope.deleteService = jasmine.createSpy('deleteService');
+          scope.inEditMode = jasmine.createSpy('inEditMode');
+          scope.inNewServiceMode = jasmine.createSpy('inNewServiceMode').and.returnValue(true);
+
           scope.deleteServiceDefinition();
           deferredSuccess.resolve();
           scope.$digest();
-          expect(p.deleteService).not.toHaveBeenCalled();
+          expect(scope.deleteService).not.toHaveBeenCalled();
         });
       });
       describe('when any of the services are in edit mode and new service is not being added', function () {
         it('does not call deleteService on parent', function () {
-          var p = jasmine.createSpyObj('$parent', ['deleteService', 'inNewServiceMode']);
-          p.inEditMode = function () { return true; };
-          scope.$parent = p;
+          scope.deleteService = jasmine.createSpy('deleteService');
+          scope.inEditMode = jasmine.createSpy('inEditMode').and.returnValue(true);
+          scope.inNewServiceMode = jasmine.createSpy('inNewServiceMode');
+
           scope.deleteServiceDefinition();
           deferredSuccess.resolve();
           scope.$digest();
-          expect(p.deleteService).not.toHaveBeenCalled();
+          expect(scope.deleteService).not.toHaveBeenCalled();
         });
       });
       describe('when any of the services are in edit mode and new service is being added', function () {
         it('does not call deleteService on parent', function () {
-          var p = jasmine.createSpyObj('$parent', ['deleteService']);
-          p.inEditMode = function () { return true; };
-          p.inNewServiceMode = function () { return true; };
-          scope.$parent = p;
+          scope.deleteService = jasmine.createSpy('deleteService');
+          scope.inEditMode = jasmine.createSpy('inEditMode').and.returnValue(true);
+          scope.inNewServiceMode = jasmine.createSpy('inNewServiceMode').and.returnValue(true);
+
           scope.deleteServiceDefinition();
           deferredSuccess.resolve();
           scope.$digest();
-          expect(p.deleteService).not.toHaveBeenCalled();
+          expect(scope.deleteService).not.toHaveBeenCalled();
         });
       });
     });
@@ -112,46 +110,50 @@ describe('Directive: actionMenu', function () {
 
     it('is triggered when the edit icon is clicked', function () {
       spyOn(scope, 'editServiceDefinition');
-      var editIcon = element.find('.icon-pencil')[0];
-      angular.element(editIcon).triggerHandler('click');
+      var editIcon = element.find('.icon-pencil');
+      editIcon.triggerHandler('click');
       expect(scope.editServiceDefinition).toHaveBeenCalled();
     });
 
     describe('when any of the services are not in edit mode and new service is not being added', function () {
       it('calls editService on the parent with the name of the service definition to be edited', function () {
-        var p = jasmine.createSpyObj('$parent', ['editService', 'inEditMode', 'inNewServiceMode']);
-        scope.$parent = p;
+        scope.editService = jasmine.createSpy('editService');
+        scope.inEditMode = jasmine.createSpy('inEditMode');
+        scope.inNewServiceMode = jasmine.createSpy('inNewServiceMode');
+
         scope.editServiceDefinition();
-        expect(p.editService).toHaveBeenCalledWith('someService');
+        expect(scope.editService).toHaveBeenCalledWith('someService');
       });
     });
 
     describe('when any of the services are not in edit mode and new service is being added', function () {
       it('does not call editService on the parent', function () {
-        var p = jasmine.createSpyObj('$parent', ['editService', 'inEditMode']);
-        p.inNewServiceMode = function () { return true; };
-        scope.$parent = p;
+        scope.editService = jasmine.createSpy('editService');
+        scope.inEditMode = jasmine.createSpy('inEditMode');
+        scope.inNewServiceMode = jasmine.createSpy('inNewServiceMode').and.returnValue(true);
+
         scope.editServiceDefinition();
-        expect(p.editService).not.toHaveBeenCalled();
+        expect(scope.editService).not.toHaveBeenCalled();
       });
     });
     describe('when any of the services are in edit mode and new service is not being added', function () {
       it('does not call editService on the parent', function () {
-        var p = jasmine.createSpyObj('$parent', ['editService', 'inNewServiceMode']);
-        p.inEditMode = function () { return true; };
-        scope.$parent = p;
+        scope.editService = jasmine.createSpy('editService');
+        scope.inEditMode = jasmine.createSpy('inEditMode').and.returnValue(true);
+        scope.inNewServiceMode = jasmine.createSpy('inNewServiceMode');
+
         scope.editServiceDefinition();
-        expect(p.editService).not.toHaveBeenCalled();
+        expect(scope.editService).not.toHaveBeenCalled();
       });
     });
     describe('when any of the services are in edit mode and new service is being added', function () {
       it('does not call editService on the parent', function () {
-        var p = jasmine.createSpyObj('$parent', ['editService']);
-        p.inEditMode = function () { return true; };
-        p.inNewServiceMode = function () { return true; };
-        scope.$parent = p;
+        scope.editService = jasmine.createSpy('editService');
+        scope.inEditMode = jasmine.createSpy('inEditMode').and.returnValue(true);
+        scope.inNewServiceMode = jasmine.createSpy('inNewServiceMode').and.returnValue(true);
+
         scope.editServiceDefinition();
-        expect(p.editService).not.toHaveBeenCalled();
+        expect(scope.editService).not.toHaveBeenCalled();
       });
     });
 

--- a/test/spec/directives/document-line.js
+++ b/test/spec/directives/document-line.js
@@ -8,9 +8,11 @@ describe('Directive: documentLine', function () {
   var element,
     compile,
     scope,
-    win;
+    win,
+    ENV;
 
-  beforeEach(inject(function ($rootScope, $compile, $window) {
+  beforeEach(inject(function ($rootScope, $compile, $window, _ENV_) {
+    ENV = _ENV_;
     win = $window;
     compile = $compile;
     scope = $rootScope.$new();
@@ -19,8 +21,8 @@ describe('Directive: documentLine', function () {
   describe('displays line information', function () {
     describe('when the line is not indented', function () {
       beforeEach(function () {
-        scope.lineObj = { text: 'blah', lineNumber: 1, errors: []};
-        element = angular.element('<document-line line="lineObj"></document-line>');
+        scope.line = { text: 'blah', lineNumber: 1, errors: []};
+        element = angular.element('<document-line></document-line>');
         element = compile(element)(scope);
         scope.$digest();
       });
@@ -40,8 +42,8 @@ describe('Directive: documentLine', function () {
 
     describe('when the line is indented', function () {
       beforeEach(function () {
-        scope.lineObj = { text: '    blah', lineNumber: 1, errors: []};
-        element = angular.element('<document-line line="lineObj"></document-line>');
+        scope.line = { text: '    blah', lineNumber: 1, errors: []};
+        element = angular.element('<document-line></document-line>');
         element = compile(element)(scope);
         scope.$digest();
       });
@@ -54,19 +56,19 @@ describe('Directive: documentLine', function () {
 
   describe('when the line has errors', function() {
     beforeEach(function () {
-      scope.lineObj = { text: 'blah', lineNumber: 1, errors: [{error:{message: 'err'}}]};
-      element = angular.element('<document-line line="lineObj"></document-line>');
+      scope.line = { text: 'blah', lineNumber: 1, errors: [{error:{message: 'err'}}]};
+      element = angular.element('<document-line></document-line>');
       element = compile(element)(scope);
       scope.$digest();
     });
 
     it('adds the warning class to the element', function () {
-      expect(element.isolateScope().lineClasses()).toEqual('warning');
+      expect(scope.lineClasses()).toEqual('warning');
       expect(element.hasClass('warning')).toBeTruthy();
     });
 
     it('shows the line-info div', function () {
-      expect(element.isolateScope().hasLineErrors()).toBeTruthy();
+      expect(scope.hasLineErrors()).toBeTruthy();
       expect(element.find('.line-info').length).not.toEqual(0);
     });
 
@@ -75,30 +77,30 @@ describe('Directive: documentLine', function () {
     });
 
     it('error message is fetched', function () {
-      expect(element.isolateScope().errMessage()).toEqual('err');
+      expect(scope.errMessage()).toEqual('err');
     });
   });
 
   describe('when the line has no errors', function () {
     beforeEach(function () {
-      scope.lineObj = { text: 'blah', lineNumber: 1, errors: []};
-      element = angular.element('<document-line line="lineObj"></document-line>');
+      scope.line = { text: 'blah', lineNumber: 1, errors: []};
+      element = angular.element('<document-line></document-line>');
       element = compile(element)(scope);
       scope.$digest();
     });
 
     it('does not add the warning class to the element', function () {
-      expect(element.isolateScope().lineClasses()).toBeNull();
+      expect(scope.lineClasses()).toBeNull();
       expect(element.hasClass('warning')).toBeFalsy();
     });
 
     it('hides the line-info div', function () {
-      expect(element.isolateScope().hasLineErrors()).toBeFalsy();
+      expect(scope.hasLineErrors()).toBeFalsy();
       expect(element.find('.line-info').length).toEqual(0);
     });
 
     it('error message is not fetched', function () {
-      expect(element.isolateScope().errMessage()).toBeNull();
+      expect(scope.errMessage()).toBeNull();
     });
 
   });
@@ -106,8 +108,8 @@ describe('Directive: documentLine', function () {
   describe('identifying attribute keys', function () {
     describe('when the line contains a service definition attribute key', function () {
       beforeEach(function () {
-        scope.lineObj = { text: 'foo: blah', lineKey: 'foo', lineValue: 'blah', lineNumber: 1, errors: []};
-        element = angular.element('<document-line line="lineObj"></document-line>');
+        scope.line = { text: 'foo: blah', lineKey: 'foo', lineValue: 'blah', lineNumber: 1, errors: []};
+        element = angular.element('<document-line></document-line>');
         element = compile(element)(scope);
         scope.$digest();
       });
@@ -118,8 +120,8 @@ describe('Directive: documentLine', function () {
     });
     describe('when the line does not contain a service definition attribute key', function () {
       beforeEach(function () {
-        scope.lineObj = { text: 'blah', lineKey: undefined, lineValue: 'blah', lineNumber: 1, errors: []};
-        element = angular.element('<document-line line="lineObj"></document-line>');
+        scope.line = { text: 'blah', lineKey: undefined, lineValue: 'blah', lineNumber: 1, errors: []};
+        element = angular.element('<document-line></document-line>');
         element = compile(element)(scope);
         scope.$digest();
       });
@@ -133,41 +135,41 @@ describe('Directive: documentLine', function () {
   describe('scope.isImageLine', function () {
     describe('when the line text does not start with "image:"', function () {
       beforeEach(function () {
-        scope.lineObj = { text: '', lineNumber: 1, errors: []};
-        element = angular.element('<document-line line="lineObj"></document-line>');
+        scope.line = { text: '', lineNumber: 1, errors: []};
+        element = angular.element('<document-line></document-line>');
         element = compile(element)(scope);
         scope.$digest();
       });
 
       it('returns false', function () {
-        expect(element.isolateScope().isImageLine()).toBeFalsy();
+        expect(scope.isImageLine()).toBeFalsy();
       });
     });
 
     describe('when the line text does start with "image:"', function () {
       describe('when the image name is not blank', function () {
         beforeEach(function () {
-          scope.lineObj = { text: 'image: foo/bar:oldest', lineNumber: 1, errors: []};
-          element = angular.element('<document-line line="lineObj"></document-line>');
+          scope.line = { text: 'image: foo/bar:oldest', lineNumber: 1, errors: []};
+          element = angular.element('<document-line></document-line>');
           element = compile(element)(scope);
           scope.$digest();
         });
 
         it('returns true', function () {
-          expect(element.isolateScope().isImageLine()).toBeTruthy();
+          expect(scope.isImageLine()).toBeTruthy();
         });
       });
 
       describe('when the image name is blank', function () {
         beforeEach(function () {
-          scope.lineObj = { text: 'image:', lineNumber: 1, errors: []};
-          element = angular.element('<document-line line="lineObj"></document-line>');
+          scope.line = { text: 'image:', lineNumber: 1, errors: []};
+          element = angular.element('<document-line></document-line>');
           element = compile(element)(scope);
           scope.$digest();
         });
 
         it('returns false', function () {
-          expect(element.isolateScope().isImageLine()).toBeFalsy();
+          expect(scope.isImageLine()).toBeFalsy();
         });
       });
 
@@ -176,29 +178,31 @@ describe('Directive: documentLine', function () {
 
   describe('scope.showImageLayers', function () {
     beforeEach(function () {
-      scope.lineObj = { text: 'image: foo/bar:oldest', lineNumber: 1, errors: []};
-      element = angular.element('<document-line line="lineObj"></document-line>');
+      scope.line = { text: 'image: foo/bar:oldest', lineNumber: 1, errors: []};
+      scope.yamlDocument = {json: {service1: {image: 'foo/bar:oldest'}, service2: {image: 'baz/quux:latest'}}};
+      element = angular.element('<document-line></document-line>');
       element = compile(element)(scope);
       scope.$digest();
     });
 
     it('opens the image with imagelayers in a new window', function () {
       spyOn(win, 'open');
-      element.isolateScope().showImageLayers();
-      expect(win.open).toHaveBeenCalledWith('http://8.22.8.236:9000/#/?images=foo%2Fbar%3Aoldest', '_blank');
+      scope.showImageLayers();
+      expect(win.open).toHaveBeenCalledWith(ENV.IMAGE_LAYERS_URL +
+        'images=foo%2Fbar%3Aoldest%2Cbaz%2Fquux%3Alatest&lock=foo%2Fbar%3Aoldest', '_blank');
     });
   });
 
   describe('scope.tooltip', function () {
     beforeEach(function () {
-      scope.lineObj = { text: 'image: foo/bar:oldest', lineNumber: 1, errors: []};
-      element = angular.element('<document-line line="lineObj"></document-line>');
+      scope.line = { text: 'image: foo/bar:oldest', lineNumber: 1, errors: []};
+      element = angular.element('<document-line></document-line>');
       element = compile(element)(scope);
       scope.$digest();
     });
 
     it('returns the image name in the tooltip', function () {
-      expect(element.isolateScope().tooltip()).toEqual('Inspect foo/bar:oldest with ImageLayers.io');
+      expect(scope.tooltip()).toEqual('Inspect foo/bar:oldest with ImageLayers.io');
     });
   });
 });

--- a/test/spec/directives/service-definition-display.js
+++ b/test/spec/directives/service-definition-display.js
@@ -23,29 +23,29 @@ describe('Directive: serviceDefinitionDisplay', function () {
 
       describe('when the serviceDefinition has no lines', function () {
         it('returns false', function () {
-          element.isolateScope().serviceDefinition = [];
-          expect(element.isolateScope().hasLines()).toBeFalsy();
+          scope.serviceDefinition = [];
+          expect(scope.hasLines()).toBeFalsy();
         });
       });
 
       describe('when the first line of the serviceDefinition starts with a dash', function () {
         it('returns false', function () {
-          element.isolateScope().serviceDefinition = [{text: '-test'}];
-          expect(element.isolateScope().hasLines()).toBeFalsy();
+          scope.serviceDefinition = [{text: '-test'}];
+          expect(scope.hasLines()).toBeFalsy();
         });
       });
 
       describe('when the first line of the serviceDefinition starts with whitespace', function () {
         it('returns false', function () {
-          element.isolateScope().serviceDefinition = [{text: ' test'}];
-          expect(element.isolateScope().hasLines()).toBeFalsy();
+          scope.serviceDefinition = [{text: ' test'}];
+          expect(scope.hasLines()).toBeFalsy();
         });
       });
 
       describe('when the first line of the serviceDefinition starts with a character other than whitespace or a dash', function () {
         it('returns true', function () {
-          element.isolateScope().serviceDefinition = [{text: 'test'}];
-          expect(element.isolateScope().hasLines()).toBeTruthy();
+          scope.serviceDefinition = [{text: 'test'}];
+          expect(scope.hasLines()).toBeTruthy();
         });
       });
     });
@@ -68,15 +68,15 @@ describe('Directive: serviceDefinitionDisplay', function () {
 
           describe('when the serviceDefinition has lines', function () {
             it('should be disabled', function () {
-              element.isolateScope().serviceDefinition = [{text: 'test'}];
-              expect(element.isolateScope().classes()).toBe('disabled');
+              scope.serviceDefinition = [{text: 'test'}];
+              expect(scope.classes()).toBe('disabled');
             });
           });
 
           describe('when the serviceDefinition has no lines', function () {
             it('should be disabled', function () {
-              element.isolateScope().serviceDefinition = [];
-              expect(element.isolateScope().classes()).toBe('disabled');
+              scope.serviceDefinition = [];
+              expect(scope.classes()).toBe('disabled');
             });
           });
         });
@@ -87,15 +87,15 @@ describe('Directive: serviceDefinitionDisplay', function () {
 
           describe('when the serviceDefinition has lines', function () {
             it('should be disabled', function () {
-              element.isolateScope().serviceDefinition = [{text: 'test'}];
-              expect(element.isolateScope().classes()).toBe('disabled');
+              scope.serviceDefinition = [{text: 'test'}];
+              expect(scope.classes()).toBe('disabled');
             });
           });
 
           describe('when the serviceDefinition has no lines', function () {
             it('should be disabled', function () {
-              element.isolateScope().serviceDefinition = [];
-              expect(element.isolateScope().classes()).toBe('disabled');
+              scope.serviceDefinition = [];
+              expect(scope.classes()).toBe('disabled');
             });
           });
         });
@@ -114,15 +114,15 @@ describe('Directive: serviceDefinitionDisplay', function () {
 
           describe('when the serviceDefinition has lines', function () {
             it('should be disabled', function () {
-              element.isolateScope().serviceDefinition = [{text: 'test'}];
-              expect(element.isolateScope().classes()).toBe('disabled');
+              scope.serviceDefinition = [{text: 'test'}];
+              expect(scope.classes()).toBe('disabled');
             });
           });
 
           describe('when the serviceDefinition has no lines', function () {
             it('should be disabled', function () {
-              element.isolateScope().serviceDefinition = [];
-              expect(element.isolateScope().classes()).toBe('disabled');
+              scope.serviceDefinition = [];
+              expect(scope.classes()).toBe('disabled');
             });
           });
         });
@@ -134,15 +134,15 @@ describe('Directive: serviceDefinitionDisplay', function () {
 
           describe('when the serviceDefinition has lines', function () {
             it('should be highlightable', function () {
-              element.isolateScope().serviceDefinition = [{text: 'test'}];
-              expect(element.isolateScope().classes()).toBe('highlightable');
+              scope.serviceDefinition = [{text: 'test'}];
+              expect(scope.classes()).toBe('highlightable');
             });
           });
 
           describe('when the serviceDefinition has no lines', function () {
             it('should be disabled', function () {
-              element.isolateScope().serviceDefinition = [];
-              expect(element.isolateScope().classes()).toBe('disabled');
+              scope.serviceDefinition = [];
+              expect(scope.classes()).toBe('disabled');
             });
           });
         });


### PR DESCRIPTION
Enabling visualization in ImageLayers of all images in the Compose YAML while locking the selected image.

In order to do this, I decided to remove the isolated scopes from the ServiceDefinitionDisplay, ActionMenu, and DocumentLine directives.  This way they can simply reference scope.yamlDocument.json rather than calling scope.$parent.$parent.$parent.$parent.

This is probably just a stop-gap pending a complete refactoring that should move yamlDocument access into some new service object.
