### PR TITLE
Adding validation warning indicator

### DIFF
--- a/app/images/icon_checkmark.svg
+++ b/app/images/icon_checkmark.svg
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 18.1.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 5 11" enable-background="new 0 0 5 11" xml:space="preserve">
+<polygon fill="#EC6425" points="1.7,4.8 5.5,1 4.6,0 1.7,2.9 0.5,1.6 -0.5,2.5 "/>
+<polygon fill="#D82328" points="1.7,11 5.5,7.2 4.6,6.2 1.7,9.1 0.5,7.8 -0.5,8.7 "/>
+</svg>

--- a/app/scripts/controllers/document-export.js
+++ b/app/scripts/controllers/document-export.js
@@ -27,7 +27,7 @@ angular.module('lorryApp').controller('DocumentExportCtrl',
       if ($scope.yamlDocument.loadFailure) {
         buttonStyle = 'button-negative';
       } else if ($scope.yamlDocument.parseErrors) {
-        buttonStyle = 'button-warning';
+        buttonStyle = 'button-error';
       } else {
         buttonStyle = 'button-primary';
       }

--- a/app/scripts/controllers/document.js
+++ b/app/scripts/controllers/document.js
@@ -84,6 +84,7 @@ angular.module('lorryApp').controller('DocumentCtrl', ['$rootScope', '$scope', '
         .then(function (response) {
           $scope.yamlDocument.lines = response.data.lines;
           $scope.yamlDocument.errors = response.data.errors;
+          $scope.yamlDocument.warnings = response.data.warnings;
           if (lodash.any(response.data.errors)) {
             $scope.yamlDocument.parseErrors = true;
             $scope.yamlDocument.loadFailure = false;

--- a/app/scripts/directives/document-alerts.js
+++ b/app/scripts/directives/document-alerts.js
@@ -11,14 +11,14 @@ angular.module('lorryApp')
 
           if (errorCount === 0) {
             element.addClass('valid');
-            element.removeClass('error warning');
+            element.removeClass('fatal error warning');
             scope.message = 'Congratulations! Your file is valid.';
             return;
           }
 
           if (scope.yamlDocument.parseErrors) {
-            element.addClass('warning');
-            element.removeClass('error valid');
+            element.addClass('error');
+            element.removeClass('warning fatal valid');
 
             if (errorCount > 1) {
               scope.message = errorCount + ' errors were possibly detected.';
@@ -26,8 +26,8 @@ angular.module('lorryApp')
               scope.message = 'An error was possibly detected.';
             }
           } else if (scope.yamlDocument.loadFailure) {
-            element.addClass('error');
-            element.removeClass('warning valid');
+            element.addClass('fatal');
+            element.removeClass('error warning valid');
 
             scope.message = 'The document supplied could not be parsed.  ';
             scope.message += scope.yamlDocument.errors[0].error.message.replace('file: ,', 'On ');

--- a/app/scripts/directives/document-line.js
+++ b/app/scripts/directives/document-line.js
@@ -6,28 +6,43 @@ angular.module('lorryApp').directive('documentLine', ['$compile', '$window', 'lo
       restrict: 'E',
       replace: true,
       link: function postLink(scope, element) {
-        function lineHtml() {
-          var html = '';
-          if (scope.line.lineKey) {
-            html += scope.line.text.replace(scope.line.lineKey + ':',
-                                            '<span class="service-key">' + scope.line.lineKey + ':</span>');
+
+        function initialize() {
+          replaceLineTextElement();
+        }
+
+        function lineValueWrapper() {
+          if (scope.hasLineWarnings()) {
+            return '<span class="service-value" tooltips tooltip-side="bottom" tooltip-size="large" tooltip-content="warningMessage()">';
           } else {
+            return '<span class="service-value">';
+          }
+        }
+
+        function lineHtml() {
+          var lineKeyReplacement,
+            html = '';
+
+          if (scope.line.lineKey) {
+            lineKeyReplacement = '<span class="service-key">' + scope.line.lineKey + ':</span>' + lineValueWrapper();
+            html += scope.line.text.replace(scope.line.lineKey + ':', lineKeyReplacement);
+          } else {
+            html += lineValueWrapper();
             html += scope.line.text;
           }
+          html += '</span>';
           return html;
         }
 
-        scope.lineClasses = function() {
-          return scope.hasLineErrors() ? 'warning' : null;
-        };
+        function replaceLineTextElement() {
+          var $lineText = element.find('.line-text'),
+            indentRegex = /(^[\s]*)/,
+            indentLevel = indentRegex.exec(scope.line.text)[0].length;
 
-        scope.hasLineErrors = function() {
-          return lodash.any(scope.line.errors);
-        };
-
-        scope.errMessage = function () {
-          return lodash.any(scope.line.errors) ? scope.line.errors[0].error.message : null;
-        };
+          var replacementLineText = angular.element('<div class="line-text">' + lineHtml() + '</div>');
+          replacementLineText.css('padding-left', (20 + indentLevel * 15) + 'px');
+          $lineText.replaceWith($compile(replacementLineText)(scope));
+        }
 
         function imageName() {
           var imageObj = jsyaml.safeLoad(scope.line.text);
@@ -37,6 +52,34 @@ angular.module('lorryApp').directive('documentLine', ['$compile', '$window', 'lo
         function imageNames() {
           return lodash.pluck(lodash.filter(scope.yamlDocument.json, 'image'), 'image');
         }
+
+        scope.lineClasses = function() {
+          var classes;
+
+          if (scope.hasLineErrors()) {
+            classes = 'error';
+          } else if (scope.hasLineWarnings()) {
+            classes = 'warning';
+          }
+
+          return classes;
+        };
+
+        scope.hasLineErrors = function() {
+          return lodash.any(scope.line.errors);
+        };
+
+        scope.hasLineWarnings = function () {
+          return lodash.any(scope.line.warnings);
+        };
+
+        scope.errMessage = function () {
+          return lodash.any(scope.line.errors) ? scope.line.errors[0].error.message : null;
+        };
+
+        scope.warningMessage = function () {
+          return lodash.any(scope.line.warnings) ? scope.line.warnings[0].warning.message : null;
+        };
 
         scope.isImageLine = function () {
           return lodash.startsWith(scope.line.text.trim(), 'image:') && !lodash.isEmpty(imageName());
@@ -53,12 +96,7 @@ angular.module('lorryApp').directive('documentLine', ['$compile', '$window', 'lo
           return 'Inspect ' + imageName() + ' with ImageLayers.io';
         };
 
-        var $lineText = element.find('.line-text'),
-          indentRegex = /(^[\s]*)/,
-          indentLevel = indentRegex.exec(scope.line.text)[0].length;
-
-        $lineText.css('padding-left', (20 + indentLevel * 15) + 'px');
-        $lineText.html(lineHtml());
+        initialize();
 
       },
       templateUrl: '/scripts/directives/document-line.html'

--- a/app/scripts/services/service-definition-transformer.js
+++ b/app/scripts/services/service-definition-transformer.js
@@ -44,7 +44,8 @@ angular.module('lorryApp').factory('serviceDefTransformer', ['$log', 'lodash', '
             lineKey: parsedLine[0],
             lineValue: parsedLine[1],
             lineNumber: lineNumber,
-            errors: lodash.select(yamlDocument.errors, { error: { line: lineNumber } })
+            errors: lodash.select(yamlDocument.errors, { error: { line: lineNumber } }),
+            warnings: lodash.select(yamlDocument.warnings, { warning: { line: lineNumber } })
           };
 
           if (/^(?:\s|-)/i.test(line)) {

--- a/app/styles/buttons.scss
+++ b/app/styles/buttons.scss
@@ -66,7 +66,7 @@ a.button-primary {
   }
 }
 
-.button-warning {
+.button-error {
   @extend .button-primary;
   background-color: $orange;
 

--- a/app/styles/document.scss
+++ b/app/styles/document.scss
@@ -82,13 +82,13 @@
 #documentAlertsPane {
   margin-right: 210px;
 
-  &.error {
+  &.fatal {
     padding: 12px;
     background-color: $dark_red;
     color: $white;
   }
 
-  &.warning {
+  &.error {
     padding: 12px;
     background-color: $orange;
     color: $white;
@@ -145,12 +145,12 @@
         }
       }
 
-      .line:not(.warning),
+      .line:not(.error),
       .action-menu {
         background-color: $darker_grey;
       }
 
-      .line:not(.warning) .line-text {
+      .line:not(.error) .line-text {
         background-color: $darkest_grey;
       }
     }
@@ -254,7 +254,7 @@
     width: 150px;
   }
 
-  .error {
+  .fatal {
     color: red;
   }
 
@@ -395,6 +395,21 @@
     text-align: right
   }
 
+  &.warning {
+    .gutter {
+      color: $orange;
+    }
+
+    .line-text .service-value {
+      display: inline-block;
+      margin-left: 5px;
+      background-image: url('../images/icon_checkmark.svg');
+      background-repeat: repeat-x;
+      background-position: 0 20px;
+      @include background-size(4px, 10px);
+    }
+  }
+
   .imagelayers {
     width: 40px;
     height: 20px;
@@ -429,7 +444,7 @@
     }
   }
 
-  &.warning {
+  &.error {
     margin-right: 120px;
     background-color: $orange;
     color: $white;
@@ -511,7 +526,7 @@ main footer {
   }
 
   .button-primary,
-  .button-warning,
+  .button-error,
   .button-negative {
     float: right;
     margin-left: 15px;

--- a/test/spec/controllers/document-export.js
+++ b/test/spec/controllers/document-export.js
@@ -68,12 +68,13 @@ describe('Controller: DocumentExportCtrl', function () {
       expect(scope.exportButtonStyle()).toEqual('button-negative');
     });
 
-    it('returns "button-warning" if there are warnings', function () {
+    it('returns "button-error" if there are errors', function () {
       scope.yamlDocument.parseErrors = true;
-      expect(scope.exportButtonStyle()).toEqual('button-warning');
+      expect(scope.exportButtonStyle()).toEqual('button-error');
     });
 
-    it('returns "button-primary" if there are no warnings', function () {
+    it('returns "button-primary" if there are no errors', function () {
+      scope.yamlDocument = {};
       expect(scope.exportButtonStyle()).toEqual('button-primary');
     });
   });

--- a/test/spec/controllers/document.js
+++ b/test/spec/controllers/document.js
@@ -170,7 +170,7 @@ describe('Controller: DocumentCtrl', function () {
       it ('builds the service definitions', function() {
         expect(scope.serviceDefinitions).toBeDefined();
         expect(scope.serviceDefinitions)
-          .toContain([{ text: 'line', lineKey: undefined, lineValue: 'line', lineNumber: 1, errors: [  ] }]);
+          .toContain([{ text: 'line', lineKey: undefined, lineValue: 'line', lineNumber: 1, errors: [] , warnings: []}]);
       });
 
       it ('sets the parseErrors flag for message display true', function () {

--- a/test/spec/directives/document-alerts.js
+++ b/test/spec/directives/document-alerts.js
@@ -22,18 +22,18 @@ describe('Directive: documentAlerts', function () {
       scope.yamlDocument.parseErrors = true;
     });
 
-    it('the warning class is added', function () {
+    it('the error class is added', function () {
       element = angular.element('<document-alerts id="documentAlertsPane"></document-alerts>');
       element = compile(element)(scope);
       scope.$digest();
-      expect(element.hasClass('warning')).toBeTruthy();
+      expect(element.hasClass('error')).toBeTruthy();
     });
 
-    it('the error class is removed', function () {
+    it('the fatal class is removed', function () {
       element = angular.element('<document-alerts id="documentAlertsPane"></document-alerts>');
       element = compile(element)(scope);
       scope.$digest();
-      expect(element.hasClass('error')).toBeFalsy();
+      expect(element.hasClass('fatal')).toBeFalsy();
     });
 
     it('the valid class is removed', function () {
@@ -86,12 +86,12 @@ describe('Directive: documentAlerts', function () {
       scope.$digest();
     });
 
-    it('the error class is added', function () {
-      expect(element.hasClass('error')).toBeTruthy();
+    it('the fatal class is added', function () {
+      expect(element.hasClass('fatal')).toBeTruthy();
     });
 
-    it('the warning class is removed', function () {
-      expect(element.hasClass('warning')).toBeFalsy();
+    it('the error class is removed', function () {
+      expect(element.hasClass('error')).toBeFalsy();
     });
 
     it('the valid class is removed', function () {

--- a/test/spec/directives/document-line.js
+++ b/test/spec/directives/document-line.js
@@ -62,9 +62,9 @@ describe('Directive: documentLine', function () {
       scope.$digest();
     });
 
-    it('adds the warning class to the element', function () {
-      expect(scope.lineClasses()).toEqual('warning');
-      expect(element.hasClass('warning')).toBeTruthy();
+    it('adds the error class to the element', function () {
+      expect(scope.lineClasses()).toEqual('error');
+      expect(element.hasClass('error')).toBeTruthy();
     });
 
     it('shows the line-info div', function () {
@@ -89,9 +89,9 @@ describe('Directive: documentLine', function () {
       scope.$digest();
     });
 
-    it('does not add the warning class to the element', function () {
-      expect(scope.lineClasses()).toBeNull();
-      expect(element.hasClass('warning')).toBeFalsy();
+    it('does not add the error class to the element', function () {
+      expect(scope.lineClasses()).toBeUndefined();
+      expect(element.hasClass('error')).toBeFalsy();
     });
 
     it('hides the line-info div', function () {
@@ -101,6 +101,47 @@ describe('Directive: documentLine', function () {
 
     it('error message is not fetched', function () {
       expect(scope.errMessage()).toBeNull();
+    });
+
+  });
+
+  describe('when the line has warnings', function() {
+    beforeEach(function () {
+      scope.line = { text: 'blah', lineNumber: 1, warnings: [{warning:{message: 'warn'}}]};
+      element = angular.element('<document-line></document-line>');
+      element = compile(element)(scope);
+      scope.$digest();
+    });
+
+    it('adds the warning class to the element', function () {
+      expect(scope.lineClasses()).toEqual('warning');
+      expect(element.hasClass('warning')).toBeTruthy();
+    });
+
+    it('adds the warning message to the line text wrapper', function () {
+      expect(element.find('.line-text > .service-value').attr('tooltip-content')).toEqual('warningMessage()');
+    });
+
+    it('scope.warningMessage returns the warning message', function () {
+      expect(scope.warningMessage()).toEqual('warn');
+    });
+  });
+
+  describe('when the line has no warnings', function () {
+    beforeEach(function () {
+      scope.line = { text: 'blah', lineNumber: 1, warnings: []};
+      element = angular.element('<document-line></document-line>');
+      element = compile(element)(scope);
+      scope.$digest();
+    });
+
+    it('does not add the warning class to the element', function () {
+      expect(scope.lineClasses()).toBeUndefined();
+      expect(element.hasClass('warning')).toBeFalsy();
+    });
+
+    it('does not add the warning message to the line text wrapper', function () {
+      expect(element.find('.line-text > .service-value').attr('tooltip-content')).toBeUndefined();
     });
 
   });

--- a/test/spec/services/service-definition-transformer.js
+++ b/test/spec/services/service-definition-transformer.js
@@ -24,7 +24,8 @@ describe('Service: service-definition-transformer', function () {
           lineNumber: 1,
           errors: [
             { error: { message: 'error1', line: 1, column: 2} }
-          ]
+          ],
+          warnings: []
         },
         {
           text: '  image: postgres:latest\ ',
@@ -33,7 +34,8 @@ describe('Service: service-definition-transformer', function () {
           lineNumber: 2,
           errors: [
             { error: { message: 'error2', line: 2, column: 3} }
-          ]
+          ],
+          warnings: []
         }
       ],
       [
@@ -44,7 +46,8 @@ describe('Service: service-definition-transformer', function () {
           lineNumber: 3,
           errors: [
             { error: { message: 'error3', line: 3, column: 2} }
-          ]
+          ],
+          warnings: []
         },
         {
           text: '  image: apache:latest\ ',
@@ -53,7 +56,8 @@ describe('Service: service-definition-transformer', function () {
           lineNumber: 4,
           errors: [
             { error: { message: 'error4', line: 4, column: 3} }
-          ]
+          ],
+          warnings: []
         }
       ]
     ];


### PR DESCRIPTION
Fatal errors are styled red
Errors are styled orange
Warnings are styled with an orange squiggly underline and an orange highlighted line number

At this time, the only available warning is for a blank image name
