### PR TITLE
Bugfix: pmx import loadfailure error display

### DIFF
--- a/app/scripts/controllers/document.js
+++ b/app/scripts/controllers/document.js
@@ -48,12 +48,14 @@
     };
 
     $scope.$watchCollection('yamlDocument.raw', function () {
-      var documentDefined = (angular.isDefined($scope.yamlDocument) && angular.isDefined($scope.yamlDocument.raw));
+      var documentDefined = (angular.isDefined($scope.yamlDocument) &&
+                             angular.isDefined($scope.yamlDocument.raw) &&
+                             !$scope.yamlDocument.loadFailure);
       if (documentDefined) {
         self.failFastOrValidateYaml();
       }
-      $scope.resettable = documentDefined;
-      $scope.importable = !documentDefined;
+      $scope.resettable = documentDefined || !!$scope.yamlDocument.loadFailure;
+      $scope.importable = !$scope.resettable;
     });
 
     this.reset = function () {

--- a/app/scripts/services/pmx-converter.js
+++ b/app/scripts/services/pmx-converter.js
@@ -9,7 +9,7 @@
 
   function PMXConverter(jsyaml) {
 
-    var convert = function (pmxYaml) {
+    function convert(pmxYaml) {
       var pmxJson, images, newJson;
 
       try {
@@ -25,9 +25,9 @@
       });
 
       return jsyaml.safeDump(newJson);
-    };
+    }
 
-    var imageToServiceDefinition = function (image) {
+    function imageToServiceDefinition(image) {
       var serviceDefinition = {};
 
       serviceDefinition.image = image.source;
@@ -40,9 +40,9 @@
       if (image.command) { serviceDefinition.command = image.command; }
 
       return serviceDefinition;
-    };
+    }
 
-    var portFlags = function (ports) {
+    function portFlags(ports) {
       return ports.map(function (port) {
         var portString = '';
 
@@ -55,9 +55,9 @@
 
         return portString;
       });
-    };
+    }
 
-    var linkFlags = function (links) {
+    function linkFlags(links) {
       return links.map(function (link) {
         var linkString = '';
 
@@ -67,21 +67,21 @@
         }
         return linkString;
       });
-    };
+    }
 
-    var exposeFlags = function (expose) {
+    function exposeFlags(expose) {
       return expose.map(function (port) {
         return port;
       });
-    };
+    }
 
-    var environmentFlags = function (environment) {
+    function environmentFlags(environment) {
       return environment.map(function (env) {
         return env.variable + '=' + env.value;
       });
-    };
+    }
 
-    var volumesFlags = function (volumes) {
+    function volumesFlags(volumes) {
       return volumes.map(function (volume) {
         var volumeString = '';
 
@@ -90,13 +90,13 @@
 
         return volumeString;
       });
-    };
+    }
 
-    var volumesFromFlags = function (volumesFrom) {
+    function volumesFromFlags(volumesFrom) {
       return volumesFrom.map(function (from) {
         return from;
       });
-    };
+    }
 
     // Public API here
     return {

--- a/test/spec/controllers/document.js
+++ b/test/spec/controllers/document.js
@@ -313,6 +313,20 @@ describe('Controller: DocumentCtrl', function () {
       it('sets $scope.importable true', function () {
         expect(scope.importable).toBe(true);
       });
+
+      describe('and there are fatal loadFailure errors', function () {
+        beforeEach(function () {
+          scope.yamlDocument.loadFailure = true;
+        });
+
+        it('sets $scope.resettable false', function () {
+          expect(scope.resettable).toBe(false);
+        });
+
+        it('sets $scope.importable true', function () {
+          expect(scope.importable).toBe(true);
+        });
+      });
     });
 
     describe('when $scope.yamlDocument.raw is defined', function () {
@@ -327,6 +341,20 @@ describe('Controller: DocumentCtrl', function () {
 
       it('sets $scope.importable false', function () {
         expect(scope.importable).toBe(false);
+      });
+
+      describe('and there are fatal loadFailure errors', function () {
+        beforeEach(function () {
+          scope.yamlDocument.loadFailure = true;
+        });
+
+        it('sets $scope.resettable false', function () {
+          expect(scope.resettable).toBe(true);
+        });
+
+        it('sets $scope.importable true', function () {
+          expect(scope.importable).toBe(false);
+        });
       });
     });
   });


### PR DESCRIPTION
Checking for loadfailure in the yamlDocument.raw to avoid validating a failed import.  This second round of validation would end up validating an empty yaml string and cause the document alert to wrongly show that the imported content is valid.
