### PR TITLE
No dismissal of fatal error alert

### DIFF
--- a/app/scripts/directives/document-alerts.html
+++ b/app/scripts/directives/document-alerts.html
@@ -1,4 +1,4 @@
 <div>
-  <div class="dismiss-alerts"><a href="" ng-click="dismiss()">Dismiss</a></div>
+  <div class="dismiss-alerts" ng-if="dismissible"><a href="" ng-click="dismiss()">Dismiss</a></div>
   {{message}}
 </div>

--- a/app/scripts/directives/document-alerts.js
+++ b/app/scripts/directives/document-alerts.js
@@ -13,6 +13,8 @@
         scope.$watch('yamlDocument', function () {
           var errorCount = scope.yamlDocument.errors ? scope.yamlDocument.errors.length : 0;
 
+          scope.dismissible = true;
+
           if (errorCount === 0) {
             element.addClass('valid');
             element.removeClass('fatal error warning');
@@ -33,6 +35,7 @@
             element.addClass('fatal');
             element.removeClass('error warning valid');
 
+            scope.dismissible = false;
             scope.message = 'The document supplied could not be parsed.  ';
             scope.message += scope.yamlDocument.errors[0].error.message.replace('file: ,', 'On ');
           }

--- a/test/spec/directives/document-alerts.js
+++ b/test/spec/directives/document-alerts.js
@@ -22,25 +22,28 @@ describe('Directive: documentAlerts', function () {
       scope.yamlDocument.parseErrors = true;
     });
 
-    it('the error class is added', function () {
-      element = angular.element('<document-alerts id="documentAlertsPane"></document-alerts>');
-      element = compile(element)(scope);
-      scope.$digest();
-      expect(element.hasClass('error')).toBeTruthy();
-    });
+    describe('always', function () {
+      beforeEach(function () {
+        element = angular.element('<document-alerts id="documentAlertsPane"></document-alerts>');
+        element = compile(element)(scope);
+        scope.$digest();
+      });
 
-    it('the fatal class is removed', function () {
-      element = angular.element('<document-alerts id="documentAlertsPane"></document-alerts>');
-      element = compile(element)(scope);
-      scope.$digest();
-      expect(element.hasClass('fatal')).toBeFalsy();
-    });
+      it('the error class is added', function () {
+        expect(element.hasClass('error')).toBeTruthy();
+      });
 
-    it('the valid class is removed', function () {
-      element = angular.element('<document-alerts id="documentAlertsPane"></document-alerts>');
-      element = compile(element)(scope);
-      scope.$digest();
-      expect(element.hasClass('valid')).toBeFalsy();
+      it('the fatal class is removed', function () {
+        expect(element.hasClass('fatal')).toBeFalsy();
+      });
+
+      it('the valid class is removed', function () {
+        expect(element.hasClass('valid')).toBeFalsy();
+      });
+
+      it('sets dismissible to true', function () {
+        expect(scope.dismissible).toBe(true);
+      });
     });
 
     describe('when there is a single error message', function () {
@@ -100,6 +103,10 @@ describe('Directive: documentAlerts', function () {
 
     it('removes the "file: ," portion of the error message', function () {
       expect(element.text()).not.toContain('file: ,');
+    });
+
+    it('sets dismissible to false', function () {
+      expect(scope.dismissible).toBe(false);
     });
   });
 


### PR DESCRIPTION
users should instead rely on the "clear workspace" button if there are fatal errors
