### PR TITLE
highlight the key red in edit mode, when there are errors present on …

### DIFF
--- a/app/styles/document.scss
+++ b/app/styles/document.scss
@@ -230,6 +230,10 @@
     }
   }
 
+  .label.error {
+    color: $dark_red;
+  }
+
   &.error,
   .error {
     input,


### PR DESCRIPTION
I had another commit that unhighlighted nested values, but Ross, Parker, and I ultimately decided that it's better without that. Here's the commit for reference: https://github.com/CenturyLinkLabs/lorry-ui/commit/8c918d71b5a08701ddcae79170c0dcd2b8d7cf7b
