### PR TITLE
Support hash for environment key

### DIFF
--- a/app/scripts/directives/service-definition-edit.js
+++ b/app/scripts/directives/service-definition-edit.js
@@ -46,6 +46,9 @@
             // if sequence type keys have string value, convert them to array
             svalue = convertSeqKeyValueToArray(svalue, skey);
 
+            // if environment key values are a sequence, convert them to a hash array
+            svalue = convertEnvironmentHashToArray(svalue, skey);
+
             // weird way to check if the array is a real array
             // or the array has objects in it
             // if [{"foo": "bar"}] the length is undefined
@@ -239,6 +242,26 @@
             }
           }
           return svalue;
+        };
+
+        var convertEnvironmentHashToArray = function (svalue, skey) {
+          // ENV_KEY_1: some value -> [ENV_KEY_1: some value]
+
+          if (skey !== 'environment') {
+            return svalue;
+          }
+          
+          var valueArr = [];
+          if (Array.isArray(svalue) && angular.isObject(svalue)) {
+            angular.forEach(svalue, function(lvalue) {
+              if (angular.isObject(lvalue)) {
+                angular.forEach(lvalue,  function(lv, lk) {
+                  valueArr.push(lk+':'+lv);
+                });
+              }
+            });
+          }
+          return valueArr;
         };
 
         var isKeyTypeSequence = function (skey) {

--- a/app/scripts/directives/service-definition-edit.js
+++ b/app/scripts/directives/service-definition-edit.js
@@ -47,7 +47,7 @@
             svalue = convertSeqKeyValueToArray(svalue, skey);
 
             // if environment key values are a sequence, convert them to a hash array
-            svalue = convertEnvironmentHashToArray(svalue, skey);
+            svalue = convertEnvironmentSeqOrHashToArray(svalue, skey);
 
             // weird way to check if the array is a real array
             // or the array has objects in it
@@ -253,9 +253,7 @@
           return svalue;
         };
 
-        var convertEnvironmentHashToArray = function (svalue, skey) {
-          // ENV_KEY_1: some value -> [ENV_KEY_1: some value]
-
+        var convertEnvironmentSeqOrHashToArray = function (svalue, skey) {
           if (skey !== 'environment') {
             return svalue;
           }
@@ -264,9 +262,13 @@
           if (Array.isArray(svalue) && angular.isObject(svalue)) {
             angular.forEach(svalue, function(lvalue) {
               if (angular.isObject(lvalue)) {
+                // {'ENV_KEY_1': 'some value'} -> ['ENV_KEY_1:some value']
                 angular.forEach(lvalue,  function(lv, lk) {
                   valueArr.push(lk+':'+lv);
                 });
+              } else {
+                // ['ENV_KEY_1=some value'] -> ['ENV_KEY_1:some value']
+                valueArr.push(lvalue.replace('=', ':'));
               }
             });
           }

--- a/app/scripts/directives/service-definition-edit.js
+++ b/app/scripts/directives/service-definition-edit.js
@@ -84,17 +84,39 @@
           var yamlFrag = {};
           angular.forEach(editedJson, function(svalue) {
             if (svalue.name === 'environment') {
-              var obj = {};
-              angular.forEach(svalue.value, function (sv) {
-                var hash = sv.split(':');
-                obj[hash[0]] = hash.length === 2 ? hash[1] : '';  // sometimes hash keys dont have any value
-              });
-              yamlFrag[svalue.name] = obj;
+              yamlFrag[svalue.name] = convertSeqSyntaxToHashSyntaxForEnvironmentVars(svalue);
             } else {
               yamlFrag[svalue.name] = svalue.value;
             }
           });
           return yamlFrag;
+        };
+
+        var convertSeqSyntaxToHashSyntaxForEnvironmentVars = function (svalue) {
+          var obj = {};
+          for(var i = 0; i < svalue.value.length; i++) {
+            var item = svalue.value[i];
+            // look for the first occurance of ':' or '='
+            // favor the ':' syntax when mixed chars ae present
+            if (item !== '') {
+              var subval = '', subkey = '';
+              var index = item.indexOf(':');
+              // if incoming value has : syntax
+              if ( index !== -1) {
+                subkey = item.substring(0, index);
+                subval = item.substring(index+1, item.length);
+              } else {
+                // if incoming value has = syntax
+                subval = ''; subkey = '';
+                index = item.indexOf('=');
+                if ( index !== -1) {
+                  subkey = item.substring(0, index);
+                  subval = item.substring(index+1, item.length);
+                }                  }
+              obj[subkey] = subval;
+            }
+          }
+          return obj;
         };
 
         scope.saveServiceDefinition = function (isFormValid) {

--- a/app/scripts/directives/service-definition-edit.js
+++ b/app/scripts/directives/service-definition-edit.js
@@ -83,7 +83,16 @@
         scope.transformToYamlDocumentFragment = function (editedJson) {
           var yamlFrag = {};
           angular.forEach(editedJson, function(svalue) {
-            yamlFrag[svalue.name] = svalue.value;
+            if (svalue.name === 'environment') {
+              var obj = {};
+              angular.forEach(svalue.value, function (sv) {
+                var hash = sv.split(':');
+                obj[hash[0]] = hash.length === 2 ? hash[1] : '';  // sometimes hash keys dont have any value
+              });
+              yamlFrag[svalue.name] = obj;
+            } else {
+              yamlFrag[svalue.name] = svalue.value;
+            }
           });
           return yamlFrag;
         };
@@ -250,7 +259,7 @@
           if (skey !== 'environment') {
             return svalue;
           }
-          
+
           var valueArr = [];
           if (Array.isArray(svalue) && angular.isObject(svalue)) {
             angular.forEach(svalue, function(lvalue) {

--- a/test/spec/directives/service-definition-edit.js
+++ b/test/spec/directives/service-definition-edit.js
@@ -370,36 +370,88 @@ describe('Directive: serviceDefinitionEdit', function () {
         });
       });
 
-    });
-
-    describe('$scope.transformToYamlDocumentFragment', function () {
-
-      describe('when editableJson is passed', function () {
+      describe('when yaml json has environment keys with seq values', function () {
         var editableJson = [
-          { name: 'build', value: 'foo'},
-          { name: 'command', value: 'bar'},
-          { name: 'ports', value: ['1111:2222', '3333:4444']},
-          { name: 'environment', value: ['foo:bar', 'flip:flop', 'dash:']}
+          { name: 'environment', value: ['foo:bar', 'flip:flop']},
+          { name: 'build', value: 'bar'}
         ];
         beforeEach(function () {
           scope.sectionName = 'adapter';
           scope.fullJson = {
             'adapter': {
-              'build': 'foo',
-              'command': 'bar',
-              'ports': ['1111:2222', '3333:4444'],
-              'environment': {'foo':'bar', 'flip':'flop', 'dash':''}
+              'environment': ['foo=bar', 'flip=flop'],
+              'build': 'bar'
             }};
           element = compile('<service-definition-edit section-name="sectionName"></service-definition-edit>')(scope);
           scope.$digest();
         });
 
-        it ('returns valid yamlDocument fragment', function () {
-          var result = element.isolateScope().transformToYamlDocumentFragment(editableJson);
-          expect(result).toEqual(scope.fullJson[scope.sectionName]);
+        it ('converts the seq values into a values array', function () {
+          var result = element.isolateScope().transformToEditableJson(scope.fullJson[scope.sectionName]);
+          expect(result).toEqual(editableJson);
         });
       });
 
+    });
+
+    describe('$scope.transformToYamlDocumentFragment', function () {
+
+      describe('when editableJson is passed', function () {
+        describe('and has hash values for environment key', function () {
+          var editableJson = [
+            {name: 'build', value: 'foo'},
+            {name: 'command', value: 'bar'},
+            {name: 'ports', value: ['1111:2222', '3333:4444']},
+            {name: 'environment', value: ['foo:bar', 'flip:flop', 'dash:']}
+          ];
+          beforeEach(function () {
+            scope.sectionName = 'adapter';
+            scope.fullJson = {
+              'adapter': {
+                'build': 'foo',
+                'command': 'bar',
+                'ports': ['1111:2222', '3333:4444'],
+                'environment': {'foo': 'bar', 'flip': 'flop', 'dash': ''}
+              }
+            };
+            element = compile('<service-definition-edit section-name="sectionName"></service-definition-edit>')(scope);
+            scope.$digest();
+          });
+
+          it('returns valid yamlDocument fragment', function () {
+            var result = element.isolateScope().transformToYamlDocumentFragment(editableJson);
+            expect(result).toEqual(scope.fullJson[scope.sectionName]);
+          });
+        });
+
+        describe('and has seq values for environment key', function () {
+          var editableJson = [
+            {name: 'build', value: 'foo'},
+            {name: 'command', value: 'bar'},
+            {name: 'ports', value: ['1111:2222', '3333:4444']},
+            {name: 'environment', value: ['foo:bar', 'flip:flop', 'dash:']}
+          ];
+          beforeEach(function () {
+            scope.sectionName = 'adapter';
+            scope.fullJson = {
+              'adapter': {
+                'build': 'foo',
+                'command': 'bar',
+                'ports': ['1111:2222', '3333:4444'],
+                'environment': {'foo': 'bar', 'flip': 'flop', 'dash': ''}
+              }
+            };
+            element = compile('<service-definition-edit section-name="sectionName"></service-definition-edit>')(scope);
+            scope.$digest();
+          });
+
+          it('returns valid yamlDocument fragment', function () {
+            var result = element.isolateScope().transformToYamlDocumentFragment(editableJson);
+            expect(result).toEqual(scope.fullJson[scope.sectionName]);
+          });
+
+        });
+      });
     });
 
     describe('$scope.saveServiceDefinition', function () {

--- a/test/spec/directives/service-definition-edit.js
+++ b/test/spec/directives/service-definition-edit.js
@@ -280,7 +280,8 @@ describe('Directive: serviceDefinitionEdit', function () {
         var editableJson = [
           { name: 'build', value: 'foo'},
           { name: 'command', value: 'bar'},
-          { name: 'ports', value: ['1111:2222', '3333:4444']}
+          { name: 'ports', value: ['1111:2222', '3333:4444']},
+          { name: 'environment', value: ['foo:bar', 'flip:flop']}
         ];
         beforeEach(function () {
           scope.sectionName = 'adapter';
@@ -288,7 +289,8 @@ describe('Directive: serviceDefinitionEdit', function () {
             'adapter': {
               'build': 'foo',
               'command': 'bar',
-              'ports': ['1111:2222', '3333:4444']
+              'ports': ['1111:2222', '3333:4444'],
+              'environment': {'foo':'bar', 'flip':'flop'}
             }};
           element = compile('<service-definition-edit section-name="sectionName"></service-definition-edit>')(scope);
           scope.$digest();
@@ -341,6 +343,28 @@ describe('Directive: serviceDefinitionEdit', function () {
         });
 
         it ('returns the string value as is', function () {
+          var result = element.isolateScope().transformToEditableJson(scope.fullJson[scope.sectionName]);
+          expect(result).toEqual(editableJson);
+        });
+      });
+
+      describe('when yaml json has environment keys with hash values', function () {
+        var editableJson = [
+          { name: 'environment', value: ['foo:bar', 'flip:flop']},
+          { name: 'build', value: 'bar'}
+        ];
+        beforeEach(function () {
+          scope.sectionName = 'adapter';
+          scope.fullJson = {
+            'adapter': {
+              'environment': {'foo':'bar', 'flip':'flop'},
+              'build': 'bar'
+            }};
+          element = compile('<service-definition-edit section-name="sectionName"></service-definition-edit>')(scope);
+          scope.$digest();
+        });
+
+        it ('converts the values hash into a values array', function () {
           var result = element.isolateScope().transformToEditableJson(scope.fullJson[scope.sectionName]);
           expect(result).toEqual(editableJson);
         });

--- a/test/spec/directives/service-definition-edit.js
+++ b/test/spec/directives/service-definition-edit.js
@@ -378,7 +378,8 @@ describe('Directive: serviceDefinitionEdit', function () {
         var editableJson = [
           { name: 'build', value: 'foo'},
           { name: 'command', value: 'bar'},
-          { name: 'ports', value: ['1111:2222', '3333:4444']}
+          { name: 'ports', value: ['1111:2222', '3333:4444']},
+          { name: 'environment', value: ['foo:bar', 'flip:flop', 'dash:']}
         ];
         beforeEach(function () {
           scope.sectionName = 'adapter';
@@ -386,7 +387,8 @@ describe('Directive: serviceDefinitionEdit', function () {
             'adapter': {
               'build': 'foo',
               'command': 'bar',
-              'ports': ['1111:2222', '3333:4444']
+              'ports': ['1111:2222', '3333:4444'],
+              'environment': {'foo':'bar', 'flip':'flop', 'dash':''}
             }};
           element = compile('<service-definition-edit section-name="sectionName"></service-definition-edit>')(scope);
           scope.$digest();


### PR DESCRIPTION
[Finishes #95282418]

- supports parsing either '=' or ':' format while importing
- saves using ':' format
- supports user entry of either '=' or ':' format while editing