### PR TITLE
Update for constraints clause and passing env vars

### DIFF
--- a/app/scripts/directives/service-definition-edit.js
+++ b/app/scripts/directives/service-definition-edit.js
@@ -316,8 +316,8 @@
                   valueArr.push(lk+':'+lv);
                 });
               } else {
-                // ['ENV_KEY_1=some value'] -> ['ENV_KEY_1:some value']
-                valueArr.push(lvalue.replace('=', ':'));
+                // ['ENV_KEY_1=some value'] -> don't change
+                valueArr.push(lvalue);
               }
             });
           }

--- a/app/scripts/directives/service-definition-edit.js
+++ b/app/scripts/directives/service-definition-edit.js
@@ -101,20 +101,28 @@
             // favor the ':' syntax when mixed chars ae present
             if (item !== '') {
               var subval = '', subkey = '';
-              var index = item.indexOf(':');
-              // if incoming value has : syntax
-              if ( index !== -1) {
-                subkey = item.substring(0, index);
-                subval = item.substring(index+1, item.length);
+              // if incoming value has neither : nor = e.g. DOCKER_HOST
+              if (item.indexOf(':') === -1 && item.indexOf('=') === -1) {
+                obj[item] = null;
               } else {
-                // if incoming value has = syntax
-                subval = ''; subkey = '';
-                index = item.indexOf('=');
+                // if incoming value has : syntax
+                var index = item.indexOf(':');
                 if ( index !== -1) {
                   subkey = item.substring(0, index);
                   subval = item.substring(index+1, item.length);
-                }                  }
-              obj[subkey] = subval;
+                  subval = subval === 'null' ? null : subval;
+                } else {
+                  // if incoming value has = syntax
+                  subval = ''; subkey = '';
+                  index = item.indexOf('=');
+                  if ( index !== -1) {
+                    subkey = item.substring(0, index);
+                    subval = item.substring(index+1, item.length);
+                    subval = subval === 'null' ? null : subval;
+                  }
+                }
+                obj[subkey] = subval;
+              }
               // If items for the environment key was marked for deletion
               // substitute the index no. by the actual key
               var envTracker = $rootScope.markAsDeletedTracker.environment;

--- a/test/spec/directives/service-definition-edit.js
+++ b/test/spec/directives/service-definition-edit.js
@@ -372,7 +372,7 @@ describe('Directive: serviceDefinitionEdit', function () {
 
       describe('when yaml json has environment keys with seq values', function () {
         var editableJson = [
-          { name: 'environment', value: ['foo:bar', 'flip:flop']},
+          { name: 'environment', value: ['foo=bar', 'flip=flop']},
           { name: 'build', value: 'bar'}
         ];
         beforeEach(function () {

--- a/test/spec/directives/service-definition-edit.js
+++ b/test/spec/directives/service-definition-edit.js
@@ -476,6 +476,29 @@ describe('Directive: serviceDefinitionEdit', function () {
           });
 
         });
+        describe('and has special seq values for environment key', function () {
+          var editableJson = [
+            {name: 'build', value: 'foo'},
+            {name: 'environment', value: ['DOCKER_HOST', 'flip=', 'dash:', 'constraint:node==swarm-master']}
+          ];
+          beforeEach(function () {
+            scope.sectionName = 'adapter';
+            scope.fullJson = {
+              'adapter': {
+                'build': 'foo',
+                'environment': {'DOCKER_HOST': null, 'flip': '', 'dash': '', 'constraint': 'node==swarm-master'}
+              }
+            };
+            element = compile('<service-definition-edit section-name="sectionName"></service-definition-edit>')(scope);
+            scope.$digest();
+          });
+
+          it('returns valid yamlDocument fragment', function () {
+            var result = element.isolateScope().transformToYamlDocumentFragment(editableJson);
+            expect(result).toEqual(scope.fullJson[scope.sectionName]);
+          });
+
+        });
 
         describe('and environment key items are marked for deletion', function () {
           var editableJson = [


### PR DESCRIPTION
[Finishes #98302724]

Support for the following syntax:

```
environment:
  DOCKER_HOST: null
  constraint: node==swarm-master
```

```
environment:
  DOCKER_HOST:
  constraint: node==swarm-master
```
and,

```
environment:
  - DOCKER_HOST
  - constraint:node==swarm-master
```
