### PR TITLE
Add a new string key for mac_address.

### DIFF
--- a/app/scripts/directives/service-definition-edit.js
+++ b/app/scripts/directives/service-definition-edit.js
@@ -330,7 +330,7 @@
         };
 
         var isKeyTypeString = function (skey) {
-          var stringKeys = ['image', 'build', 'net', 'pid', 'working_dir', 'entrypoint', 'user', 'hostname', 'domainname', 'mem_limit', 'privileged', 'restart', 'stdin_open', 'tty', 'cpu_shares'];
+          var stringKeys = ['image', 'build', 'net', 'pid', 'working_dir', 'entrypoint', 'user', 'hostname', 'domainname', 'mac_address', 'mem_limit', 'privileged', 'restart', 'stdin_open', 'tty', 'cpu_shares'];
           return lodash.includes(stringKeys, skey);
         };
 


### PR DESCRIPTION
[Finishes #101449176]

The standard (IEEE 802) format for printing MAC-48 addresses in human-friendly form is six groups of two hexadecimal digits, separated by hyphens - or colons :

![image](https://cloud.githubusercontent.com/assets/8188/9337364/f769bb1e-45ac-11e5-9f89-4417ea620913.png)